### PR TITLE
Make xarray an optional dependency

### DIFF
--- a/.travis/python2.docker
+++ b/.travis/python2.docker
@@ -3,6 +3,11 @@ RUN docker-apt-install python-pip python-casacore
 RUN pip install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
+# Test without xarray
 RUN pip install .[testing]
+RUN pip freeze
+RUN py.test --flake8 -s -vvv /code/daskms
+# Retest with xarray installed
+RUN pip install .[testing,xarray]
 RUN pip freeze
 RUN py.test --flake8 -s -vvv /code/daskms

--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -3,6 +3,11 @@ RUN docker-apt-install python3-pip python3-casacore
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
+# Test without xarray
 RUN pip3 install .[testing]
+RUN pip3 freeze
+RUN py.test --flake8 -s -vvv /code/daskms
+# Retest with xarray installed
+RUN pip3 install .[testing,xarray]
 RUN pip3 freeze
 RUN py.test --flake8 -s -vvv /code/daskms

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -3,6 +3,11 @@ RUN docker-apt-install python3-pip python3-casacore
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code
+# Test without xarray
 RUN pip3 install .[testing]
+RUN pip3 freeze
+RUN py.test --flake8 -s -vvv /code/daskms
+# Retest with xarray installed
+RUN pip3 install .[testing,xarray]
 RUN pip3 freeze
 RUN py.test --flake8 -s -vvv /code/daskms

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.10 (YYYY-MM-DD)
 -------------------
 
+* Make xarray an optional dependency (:pr:`45`)
 * Rename xarray-ms to dask-ms (:pr:`43`)
 * Allow chunking by arbitrary dimensions (:pr:`41`)
 * Add a simple Dataset, making xarray an optional dependency. (:pr:`41`)

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,27 @@ The intention behind this package is to support the Measurement Set as
 a data source and sink for the purposes of writing parallel, distributed
 Radio Astronomy algorithms.
 
+Installation
+============
+
+To install with xarray_ support:
+
+.. code-block:: bash
+
+  $ pip install dask-ms[xarray]
+
+Without xarray_ similar, but reduced Dataset functionality is replicated
+in dask-ms itself. Expert users may wish to use this option to reduce
+python package dependencies.
+
+.. code-block:: bash
+
+  $ pip install dask-ms
+
+Example Usage
+=============
+
+
 .. code-block:: python
 
     import dask.array as da

--- a/daskms/dataset.py
+++ b/daskms/dataset.py
@@ -159,7 +159,7 @@ class Dataset(object):
         return data_var_chunks(self._data_vars)
 
     @property
-    def variables(self):
+    def data_vars(self):
         return Frozen(self._data_vars)
 
     @property
@@ -192,6 +192,16 @@ class Dataset(object):
             pass
 
         try:
+            return self._coords[name]
+        except KeyError:
+            pass
+
+        try:
             return self._attrs[name]
         except KeyError:
             raise AttributeError("Invalid Attribute %s" % name)
+
+    def copy(self):
+        return Dataset(self._data_vars,
+                       attrs=self._attrs.copy(),
+                       coords=self._coords)

--- a/daskms/descriptors/builder.py
+++ b/daskms/descriptors/builder.py
@@ -70,7 +70,7 @@ class AbstractDescriptorBuilder(object):
             datasets = list(datasets)
 
         for ds in datasets:
-            for column, variable in ds.variables.items():
+            for column, variable in ds.data_vars.items():
                 variables[column].append(variable)
 
         return variables

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -290,6 +290,8 @@ class DatasetFactory(object):
                                               single_row=single_row)
 
         if single_row:
+            # ROWID is assigned as an attribute
+            del variables['ROWID']
             return Dataset(variables, attrs={"ROWID": exemplar_row})
         else:
             return Dataset(variables)

--- a/daskms/tests/test_dataset.py
+++ b/daskms/tests/test_dataset.py
@@ -59,7 +59,7 @@ def test_dataset(ms, select_cols, group_cols, index_cols, shapes, chunks):
     for ds in datasets:
         compute_dict = {}
 
-        for k, v in ds.variables.items():
+        for k, v in ds.data_vars.items():
             compute_dict[k] = v.data
 
             if k in select_cols:
@@ -186,7 +186,7 @@ def test_antenna_table_string_names(ant_table, wsrt_antenna_positions):
     # Test that writing back string ndarrays work as
     # they must be converted from ndarrays to lists
     # of strings internally
-    write_cols = set(ds.variables.keys()) - set(["ROWID"])
+    write_cols = set(ds.data_vars.keys()) - set(["ROWID"])
     writes = write_datasets(ant_table, ds, write_cols)
 
     dask.compute(writes)
@@ -238,7 +238,7 @@ def test_dataset_table_schemas(ms):
     data_dims = ("mychan", "mycorr")
     table_schema = ["MS", {"DATA": {'dask': {"dims": data_dims}}}]
     datasets = read_datasets(ms, [], [], [], table_schema=table_schema)
-    assert datasets[0].variables["DATA"].dims == ("row", ) + data_dims
+    assert datasets[0].data_vars["DATA"].dims == ("row", ) + data_dims
 
 
 @pytest.mark.parametrize("dtype", [

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -190,7 +190,7 @@ def update_datasets(table, datasets, columns, descriptor):
     # those without (which imply appends to the MS)
     # are handled last
     sorted_datasets = sorted(enumerate(datasets),
-                             key=lambda t: ("ROWID" not in t[1].variables,
+                             key=lambda t: ("ROWID" not in t[1].data_vars,
                                             t[0]))
 
     # Establish row orders for each dataset
@@ -222,7 +222,7 @@ def update_datasets(table, datasets, columns, descriptor):
     assert len(row_orders) == len(datasets)
 
     for (di, ds), row_order in zip(sorted_datasets, row_orders):
-        data_vars = ds.variables
+        data_vars = ds.data_vars
 
         # Generate a dask array for each column
         for column in columns:
@@ -368,7 +368,7 @@ def add_row_order_factory(table_proxy, datasets):
     row_add_ops = []
 
     for di, ds in enumerate(datasets):
-        data_vars = ds.variables
+        data_vars = ds.data_vars
         found = False
 
         for k, (dims, array, _) in data_vars.items():
@@ -415,7 +415,7 @@ def create_datasets(table_name, datasets, columns, descriptor):
     writes = []
 
     for di, (ds, row_order) in enumerate(zip(datasets, row_orders)):
-        data_vars = ds.variables
+        data_vars = ds.data_vars
 
         for column in columns:
             try:
@@ -469,7 +469,7 @@ def write_datasets(table, datasets, columns, descriptor=None):
 
     # If no columns are defined, write all dataset variables by default
     if not columns:
-        columns = set.union(*(set(ds.variables.keys()) for ds in datasets))
+        columns = set.union(*(set(ds.data_vars.keys()) for ds in datasets))
         columns = list(sorted(columns))
 
     if not table_exists(table):

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,16 @@ except ImportError as e:
     raise ImportError("%s\nPlease install setuptools." % e)
 
 extras_require = {
+    'xarray': ["xarray > 0.10.0; python_version < '3.0'",
+               "xarray > 0.12.0; python_version >= '3.5'"],
     'testing': ['mock', 'pytest', 'pytest-flake8']
 }
 
 install_requires = [
-    "dask[array] >= 1.1.0",
+    "dask[array] == 1.2.2; python_version < '3.0'",
+    "dask[array] >= 2.2.0; python_version >= '3.5'",
     "futures >= 3.2.0; python_version < '3.0'",
     "six >= 1.10.0",
-    "xarray >= 0.10.0",
 ]
 
 # ==================


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
