### PR TITLE
Small fixes and improvements based on tricolour integration

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,6 @@ History
 * Rename xarray-ms to dask-ms (:pr:`43`)
 * Allow chunking by arbitrary dimensions (:pr:`41`)
 * Add a simple Dataset, making xarray an optional dependency.
-  (:pr:`41`, :pr:`46`)
+  (:pr:`41`, :pr:`46`, :pr:`47`)
 * Add support for writing new tables from Datasets (:pr:`41`)
 * Add support for appending to tables from Datasets (:pr:`41`)

--- a/daskms/columns.py
+++ b/daskms/columns.py
@@ -173,15 +173,14 @@ def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
     else:
         try:
             # Get an exemplar row and infer the shape
-            exemplar = table_proxy.getcol(column, exemplar_row,
-                                          nrow=1).result()
+            exemplar = table_proxy.getcell(column, exemplar_row).result()
         except Exception as e:
             raise ColumnMetadataError("Unable to infer shape of "
                                       "column '%s' due to:\n'%s'"
                                       % (column, str(e)))
 
         if isinstance(exemplar, np.ndarray):
-            shape = exemplar.shape[1:]
+            shape = exemplar.shape
 
             # Double-check the dtype
             if dtype != exemplar.dtype:
@@ -204,7 +203,7 @@ def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
     try:
         dims = table_schema[column]['dask']['dims']
     except KeyError:
-        dims = tuple("%s-%d" % (column, i) for i in range(1, len(shape)))
+        dims = tuple("%s-%d" % (column, i) for i in range(len(shape)))
 
     dim_chunks = []
 

--- a/daskms/dask_ms.py
+++ b/daskms/dask_ms.py
@@ -53,6 +53,8 @@ def xds_to_table(xds, table_name, columns=None, **kwargs):
     if not isinstance(xds, (tuple, list)):
         xds = [xds]
 
+    columns = promote_columns(columns, [])
+
     datasets = []
 
     # No xarray available, assume dask datasets

--- a/daskms/table.py
+++ b/daskms/table.py
@@ -25,4 +25,6 @@ def table_descriptor(table):
 
 
 def table_exists(table):
+    table = table.replace("::", os.sep)
+
     return os.path.exists(table) and os.path.isdir(table)

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -45,6 +45,7 @@ _proxied_methods = [
     ("getcol", READLOCK),
     ("getcolnp", READLOCK),
     ("getvarcol", READLOCK),
+    ("getcell", READLOCK),
     ("getcellslice", READLOCK),
     # Writes
     ("putcol", WRITELOCK),

--- a/daskms/table_schemas.py
+++ b/daskms/table_schemas.py
@@ -98,7 +98,7 @@ POLARIZATION = {
         'dask': {'dims': ('corr',)},
     },
     "CORR_PRODUCT": {
-        'dask': {'corr', 'corrprod_idx'},
+        'dask': {'dims': ('corr', 'corrprod_idx')},
     },
 }
 

--- a/daskms/tests/conftest.py
+++ b/daskms/tests/conftest.py
@@ -139,7 +139,7 @@ def spw_chan_freqs():
 def spw_table(tmp_path_factory, spw_chan_freqs):
     """ Simulate a SPECTRAL_WINDOW table with two spectral windows """
     spw_dir = tmp_path_factory.mktemp("spw_dir", numbered=True)
-    fn = os.path.join(str(spw_dir), "test.ms::SPECTRAL_WINDOW")
+    fn = os.path.join(str(spw_dir), "SPECTRAL_WINDOW")
 
     create_table_query = """
     CREATE TABLE %s
@@ -188,7 +188,7 @@ def wsrt_antenna_positions():
 @pytest.fixture
 def ant_table(tmp_path_factory, wsrt_antenna_positions):
     ant_dir = tmp_path_factory.mktemp("ant_dir", numbered=True)
-    fn = os.path.join(str(ant_dir), "test.ms::ANTENNA")
+    fn = os.path.join(str(ant_dir), "ANTENNA")
 
     create_table_query = """
     CREATE TABLE %s

--- a/daskms/tests/test_dataset.py
+++ b/daskms/tests/test_dataset.py
@@ -348,3 +348,21 @@ def test_dataset_create_table(tmp_path, dataset_chunks, dtype):
         assert row_sum == T.nrows()
         assert_array_equal(T.getcol("DATA"), np.concatenate(datas))
         assert_array_equal(T.getcol("NAMES"), names)
+
+
+def test_dataset_computes_and_values(ms):
+    datasets = read_datasets(ms, [], [], [])
+    assert len(datasets) == 1
+    ds = datasets[0]
+
+    # All dask arrays
+    for k, v in ds.data_vars.items():
+        assert isinstance(v.data, da.Array)
+
+    nds = ds.compute()
+
+    # Now we have numpy arrays that match original data
+    for k, v in nds.data_vars.items():
+        assert isinstance(v.data, np.ndarray)
+        assert_array_equal(v.data, ds.data_vars[k].data)
+        assert_array_equal(v.values, ds.data_vars[k].data)

--- a/daskms/tests/test_table.py
+++ b/daskms/tests/test_table.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from os.path import join as pjoin
+
+from daskms.table import table_exists
+
+import pytest
+
+
+def test_table_exists(tmp_path):
+    ms_path = tmp_path / "test.ms"
+    ms_path.mkdir(parents=True, exist_ok=False)
+    assert table_exists(str(ms_path)) is True
+
+    ant_path = ms_path / "ANTENNA"
+    ant_path.mkdir(parents=True, exist_ok=False)
+    # Both the directory and canonical subtable access forms work
+    assert table_exists(str(ant_path))
+    assert table_exists('::'.join((str(ms_path), "ANTENNA")))

--- a/daskms/tests/test_table.py
+++ b/daskms/tests/test_table.py
@@ -4,11 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from os.path import join as pjoin
-
 from daskms.table import table_exists
-
-import pytest
 
 
 def test_table_exists(tmp_path):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
