### PR TITLE
Don't align arrays on create/update

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,5 +19,5 @@ History
 * Allow chunking by arbitrary dimensions (:pr:`41`)
 * Add a simple Dataset, making xarray an optional dependency.
   (:pr:`41`, :pr:`46`, :pr:`47`, :pr:`52`)
-* Add support for writing new tables from Datasets (:pr:`41`)
+* Add support for writing new tables from Datasets (:pr:`41`, :pr:`53`)
 * Add support for appending to tables from Datasets (:pr:`41`)

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -317,6 +317,7 @@ def update_datasets(table, datasets, columns, descriptor):
                                      # a single bool is returned
                                      adjust_chunks={d: 1 for d in full_dims},
                                      name=name,
+                                     align_arrays=False,
                                      dtype=np.bool)
 
             writes.append(write_col.ravel())
@@ -521,6 +522,7 @@ def create_datasets(table_name, datasets, columns, descriptor):
                                      # a single bool is returned
                                      adjust_chunks={d: 1 for d in dims},
                                      name=name,
+                                     align_arrays=False,
                                      dtype=np.bool)
 
             # Flatten the writes so that they can be simply


### PR DESCRIPTION
So we can handle nan row chunks.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
