### PR TITLE
Fix WEIGHT_SPECTRUM dims

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.2.0 (YYYY-MM-DD)
 ------------------
 
+* Fix WEIGHT_SPECTRUM schema dimensions (:pr:`56`)
 * Pin python-casacore to 3.0.0 (:pr:`54`)
 * Drop python 2 support (:pr:`51`)
 * Simplify Table Schemas (:pr:`50`)

--- a/daskms/table_schemas.py
+++ b/daskms/table_schemas.py
@@ -20,7 +20,7 @@ MS_SCHEMA = {
     'SIGMA': {'dims': ('corr',)},
     'SIGMA_SPECTRUM': {'dims': ('chan', 'corr')},
     'WEIGHT': {'dims': ('corr',)},
-    'WEIGHT_SPECTRUM': {('chan', 'corr')},
+    'WEIGHT_SPECTRUM': {'dims': ('chan', 'corr')},
     'FLAG': {'dims': ('chan', 'corr')},
     'FLAG_CATEGORY': {'dims': ('flagcat', 'chan', 'corr')},
     # Extra imaging columns


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
