### PR TITLE
Support concurrent access of independent tables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.2.0 (YYYY-MM-DD)
 ------------------
 
+* Support concurrent access of multiple independent tables (:pr:`57`)
 * Fix WEIGHT_SPECTRUM schema dimensions (:pr:`56`)
 * Pin python-casacore to 3.0.0 (:pr:`54`)
 * Drop python 2 support (:pr:`51`)

--- a/daskms/descriptors/builder_factory.py
+++ b/daskms/descriptors/builder_factory.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import ast
 
 from daskms.utils import short_table_name
+from daskms.table_schemas import SUBTABLES
 
 
 class ParseFunctionCallError(Exception):
@@ -98,7 +99,7 @@ def filename_builder_factory(filename):
     from daskms.descriptors.ms_subtable import MSSubTableDescriptorBuilder
 
     # Perhaps its an MS subtable?
-    for subtable in MSSubTableDescriptorBuilder.SUBTABLES:
+    for subtable in SUBTABLES:
         if canonical_name.endswith(subtable):
             return MSSubTableDescriptorBuilder(subtable)
 

--- a/daskms/descriptors/ms_subtable.py
+++ b/daskms/descriptors/ms_subtable.py
@@ -8,18 +8,13 @@ import pyrap.tables as pt
 
 from daskms.descriptors.builder import (register_descriptor_builder,
                                         AbstractDescriptorBuilder)
+from daskms.table_schemas import SUBTABLES
 
 
 @register_descriptor_builder("mssubtable")
 class MSSubTableDescriptorBuilder(AbstractDescriptorBuilder):
-    SUBTABLES = ("ANTENNA", "DATA_DESCRIPTION", "DOPPLER",
-                 "FEED", "FIELD", "FLAG_CMD", "FREQ_OFFSET",
-                 "HISTORY", "OBSERVATION", "POINTING", "POLARIZATION",
-                 "PROCESSOR", "SOURCE", "SPECTRAL_WINDOW", "STATE",
-                 "SYSCAL", "WEATHER")
-
     def __init__(self, subtable):
-        if subtable not in self.SUBTABLES:
+        if subtable not in SUBTABLES:
             raise ValueError("'%s' is not a valid Measurement Set "
                              "sub-table" % subtable)
 

--- a/daskms/descriptors/tests/test_ms_subtable_builder.py
+++ b/daskms/descriptors/tests/test_ms_subtable_builder.py
@@ -12,9 +12,10 @@ import pytest
 
 from daskms.dataset import Variable
 from daskms.descriptors.ms_subtable import MSSubTableDescriptorBuilder
+from daskms.table_schemas import SUBTABLES
 
 
-@pytest.mark.parametrize("table", MSSubTableDescriptorBuilder.SUBTABLES)
+@pytest.mark.parametrize("table", SUBTABLES)
 def test_ms_subtable_builder(tmp_path, table):
     A = da.zeros((10, 20, 30), chunks=(2, 20, 30), dtype=np.int32)
     variables = {"FOO": Variable(("row", "chan", "corr"), A, {})}

--- a/daskms/ordering.py
+++ b/daskms/ordering.py
@@ -75,7 +75,8 @@ def ordering_taql(table_proxy, index_cols, taql_where=''):
 
     query = "%s\nFROM\n\t$1\n%s%s" % (select, orderby, taql_where)
 
-    return TableProxy(taql_factory, query, tables=[table_proxy])
+    return TableProxy(taql_factory, query, tables=[table_proxy],
+                      __executor_key__=table_proxy.executor_key)
 
 
 def row_ordering(taql_proxy, index_cols, chunks):
@@ -183,7 +184,8 @@ def group_ordering_taql(table_proxy, group_cols, index_cols, taql_where=''):
 
         query = "%s\nFROM\n\t$1\n%s%s" % (select, groupby, taql_where)
 
-        return TableProxy(taql_factory, query, tables=[table_proxy])
+        return TableProxy(taql_factory, query, tables=[table_proxy],
+                          __executor_key__=table_proxy.executor_key)
 
     raise RuntimeError("Invalid condition in group_ordering_taql")
 

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -16,6 +16,7 @@ from daskms.columns import (column_metadata, ColumnMetadataError,
 from daskms.ordering import (ordering_taql, row_ordering,
                              group_ordering_taql, group_row_ordering)
 from daskms.dataset import Dataset
+from daskms.table_executor import executor_key
 from daskms.table import table_exists
 from daskms.table_proxy import TableProxy, READLOCK
 from daskms.table_schemas import lookup_table_schema
@@ -281,7 +282,8 @@ class DatasetFactory(object):
 
     def _table_proxy(self):
         return TableProxy(pt.table, self.table, ack=False,
-                          readonly=True, lockoptions='user')
+                          readonly=True, lockoptions='user',
+                          __executor_key__=executor_key(self.table))
 
     def _table_schema(self):
         return lookup_table_schema(self.table, self.table_schema)

--- a/daskms/table_schemas.py
+++ b/daskms/table_schemas.py
@@ -11,6 +11,14 @@ except ImportError:
 
 from daskms.utils import short_table_name
 
+# Measurement Set sub-tables
+SUBTABLES = ("ANTENNA", "DATA_DESCRIPTION", "DOPPLER",
+             "FEED", "FIELD", "FLAG_CMD", "FREQ_OFFSET",
+             "HISTORY", "OBSERVATION", "POINTING", "POLARIZATION",
+             "PROCESSOR", "SOURCE", "SPECTRAL_WINDOW", "STATE",
+             "SYSCAL", "WEATHER")
+
+
 # https://casa.nrao.edu/Memos/229.html#SECTION00061000000000000000
 MS_SCHEMA = {
     'UVW': {'dims': ('uvw',)},

--- a/daskms/tests/test_executor.py
+++ b/daskms/tests/test_executor.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+import pytest
+
+from daskms.table_executor import Executor, _executor_cache, executor_key
+
+
+def test_executor():
+    """ Test the executor """
+    ex = Executor()
+    ex2 = Executor()
+    assert ex is ex2
+
+    ex3 = pickle.loads(pickle.dumps(ex))
+
+    assert ex3 is ex
+
+    assert len(_executor_cache) == 1
+
+    assert ex.impl.submit(lambda x: x*2, 4).result() == 8
+    ex.shutdown(wait=True)
+    ex3.shutdown(wait=False)
+
+    # Executor should be shutdown at this point
+    with pytest.raises(RuntimeError):
+        ex2.impl.submit(lambda x: x*2, 4)
+
+    assert len(_executor_cache) == 1
+
+    # Force collection
+    del ex, ex2, ex3
+
+    # Check that callbacks
+    assert len(_executor_cache) == 0
+
+
+@pytest.mark.parametrize("key, result", [
+    ('/home/moriarty/test.ms/', '/home/moriarty/test.ms'),
+    ('/home/moriarty/test.ms', '/home/moriarty/test.ms'),
+    ('/home/moriarty/test.ms/::FIELD', '/home/moriarty/test.ms'),
+    ('/home/moriarty/test.ms::FIELD', '/home/moriarty/test.ms'),
+    ('/home/moriarty/test.ms::FIELD/', '/home/moriarty/test.ms'),
+    ('/home/moriarty/test.ms::QUX/', '/home/moriarty/test.ms'),
+    ('/home/moriarty/::test.ms::QUX/', '/home/moriarty/::test.ms'),
+])
+def test_executor_key(key, result):
+    assert executor_key(key) == result

--- a/daskms/tests/test_table_proxy.py
+++ b/daskms/tests/test_table_proxy.py
@@ -17,39 +17,9 @@ from numpy.testing import assert_array_equal
 import pyrap.tables as pt
 import pytest
 
-from daskms.table_executor import Executor, _executor_cache
 from daskms.table_proxy import (TableProxy, _table_cache, taql_factory,
                                 MismatchedLocks, READLOCK, WRITELOCK, NOLOCK)
 from daskms.utils import assert_liveness
-
-
-def test_executor():
-    """ Test the executor """
-    ex = Executor()
-    ex2 = Executor()
-    assert ex is ex2
-
-    ex3 = pickle.loads(pickle.dumps(ex))
-
-    assert ex3 is ex
-
-    assert len(_executor_cache) == 1
-
-    assert ex.impl.submit(lambda x: x*2, 4).result() == 8
-    ex.shutdown(wait=True)
-    ex3.shutdown(wait=False)
-
-    # Executor should be shutdown at this point
-    with pytest.raises(RuntimeError):
-        ex2.impl.submit(lambda x: x*2, 4)
-
-    assert len(_executor_cache) == 1
-
-    # Force collection
-    del ex, ex2, ex3
-
-    # Check that callbacks
-    assert len(_executor_cache) == 0
 
 
 def test_table_proxy(ms):

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -18,6 +18,7 @@ from daskms.descriptors.builder_factory import filename_builder_factory
 from daskms.descriptors.builder_factory import string_builder_factory
 from daskms.ordering import row_run_factory
 from daskms.table import table_exists
+from daskms.table_executor import executor_key
 from daskms.table_proxy import TableProxy, WRITELOCK
 from daskms.utils import short_table_name
 
@@ -181,12 +182,14 @@ def _create_table(table, datasets, columns, descriptor):
             pass
 
     return TableProxy(pt.table, table, ack=False,
-                      readonly=False, lockoptions='user')
+                      readonly=False, lockoptions='user',
+                      __executor_key__=executor_key(table))
 
 
 def _updated_table(table, datasets, columns, descriptor):
     table_proxy = TableProxy(pt.table, table, ack=False,
-                             readonly=False, lockoptions='user')
+                             readonly=False, lockoptions='user',
+                             __executor_key__=executor_key(table))
 
     table_columns = set(table_proxy.colnames().result())
     missing = set(columns) - table_columns


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
