### PR TITLE
Support table keywords

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.2.0 (YYYY-MM-DD)
 ------------------
 
+* Support table and column keywords (:pr:`58`)
 * Support concurrent access of multiple independent tables (:pr:`57`)
 * Fix WEIGHT_SPECTRUM schema dimensions (:pr:`56`)
 * Pin python-casacore to 3.0.0 (:pr:`54`)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -317,6 +317,9 @@ class DatasetFactory(object):
 
         assert len(group_ids) == len(orders)
 
+        # Table keywords
+        keywords = table_proxy.getkeywords().result()
+
         # Select columns, excluding grouping columns
         select_cols = set(self.select_cols or table_proxy.colnames().result())
         select_cols -= set(self.group_cols)
@@ -354,7 +357,11 @@ class DatasetFactory(object):
             # Assign values for the dataset's grouping columns
             # as attributes
             attrs = dict(zip(self.group_cols, group_id))
-            attrs['keywords'] = table_proxy.getkeywords().result()
+
+            # Add any table keywords
+            if len(keywords) > 0:
+                attrs['keywords'] = keywords
+
             datasets.append(Dataset(group_var_dims, attrs=attrs,
                                     coords=coords))
 

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -292,6 +292,7 @@ class DatasetFactory(object):
         table_proxy = self._table_proxy()
         table_schema = self._table_schema()
         select_cols = set(self.select_cols or table_proxy.colnames().result())
+        keywords = table_proxy.getkeywords().result()
 
         variables = _dataset_variable_factory(table_proxy, table_schema,
                                               select_cols, exemplar_row,
@@ -305,7 +306,7 @@ class DatasetFactory(object):
         else:
             coords = {"ROWID": rowid}
 
-        return Dataset(variables, coords=coords)
+        return Dataset(variables, coords=coords, attrs={"keywords": keywords})
 
     def _group_datasets(self, groups, exemplar_rows, orders):
         table_proxy = self._table_proxy()
@@ -353,6 +354,7 @@ class DatasetFactory(object):
             # Assign values for the dataset's grouping columns
             # as attributes
             attrs = dict(zip(self.group_cols, group_id))
+            attrs['keywords'] = table_proxy.getkeywords().result()
             datasets.append(Dataset(group_var_dims, attrs=attrs,
                                     coords=coords))
 

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -46,12 +46,14 @@ _proxied_methods = [
     ("getvarcol", READLOCK),
     ("getcell", READLOCK),
     ("getcellslice", READLOCK),
+    ("getkeywords", READLOCK),
     ("getcolkeywords", READLOCK),
     # Writes
     ("putcol", WRITELOCK),
     ("putcolnp", WRITELOCK),
     ("putvarcol", WRITELOCK),
     ("putcellslice", WRITELOCK),
+    ("putkeywords", WRITELOCK),
     ("putcolkeywords", WRITELOCK)]
 
 

--- a/daskms/tests/test_keywords.py
+++ b/daskms/tests/test_keywords.py
@@ -9,7 +9,7 @@ import pyrap.tables as pt
 import pytest
 
 from daskms.example_data import example_ms
-from daskms import xds_to_table, xds_from_ms, Dataset
+from daskms import xds_to_table, xds_from_ms
 
 
 @pytest.fixture(scope='module')
@@ -32,7 +32,6 @@ def test_keyword_read(keyword_ms, table_kw, column_kw):
                       column_keywords=column_kw)
 
     if isinstance(ret, tuple):
-        datasets = ret[0]
         ret_pos = 1
 
         if table_kw is True:
@@ -61,7 +60,6 @@ def test_keyword_write(ms):
 
     with pt.table(ms, ack=False, readonly=True) as T:
         assert T.getkeywords()['bob'] == 'qux'
-        nrows = T.nrows()
 
     # Add to column keywords
     writes = xds_to_table(datasets, ms, [],
@@ -81,4 +79,3 @@ def test_keyword_write(ms):
     with pt.table(ms, ack=False, readonly=True) as T:
         assert 'bob' not in T.getkeywords()
         assert 'bob' not in T.getcolkeywords("STATE_ID")
-

--- a/daskms/tests/test_keywords.py
+++ b/daskms/tests/test_keywords.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import dask
+import pyrap.tables as pt
+import pytest
+
+from daskms.example_data import example_ms
+from daskms import xds_to_table, xds_from_ms, Dataset
+
+
+@pytest.fixture(scope='module')
+def keyword_ms():
+    try:
+        yield example_ms()
+    finally:
+        pass
+
+
+@pytest.mark.parametrize("table_kw", [True, False])
+@pytest.mark.parametrize("column_kw", [True, False])
+def test_keyword_read(keyword_ms, table_kw, column_kw):
+    # Create an example MS
+    with pt.table(keyword_ms, ack=False, readonly=True) as T:
+        desc = T._getdesc(actual=True)
+
+    ret = xds_from_ms(keyword_ms,
+                      table_keywords=table_kw,
+                      column_keywords=column_kw)
+
+    if isinstance(ret, tuple):
+        datasets = ret[0]
+        ret_pos = 1
+
+        if table_kw is True:
+            assert desc["_keywords_"] == ret[ret_pos]
+            ret_pos += 1
+
+        if column_kw is True:
+            colkw = ret[ret_pos]
+
+            for column, keywords in colkw.items():
+                assert desc[column]['keywords'] == keywords
+
+            ret_pos += 1
+    else:
+        assert table_kw is False
+        assert column_kw is False
+        assert isinstance(ret, list)
+
+
+def test_keyword_write(ms):
+    datasets = xds_from_ms(ms)
+
+    # Add to table keywords
+    writes = xds_to_table([], ms, [], table_keywords={'bob': 'qux'})
+    dask.compute(writes)
+
+    with pt.table(ms, ack=False, readonly=True) as T:
+        assert T.getkeywords()['bob'] == 'qux'
+        nrows = T.nrows()
+
+    # Add to column keywords
+    writes = xds_to_table(datasets, ms, [],
+                          column_keywords={'STATE_ID': {'bob': 'qux'}})
+    dask.compute(writes)
+
+    with pt.table(ms, ack=False, readonly=True) as T:
+        assert T.getcolkeywords("STATE_ID")['bob'] == 'qux'
+
+    # Remove from column and table keywords
+    from daskms.writes import DELKW
+    writes = xds_to_table(datasets, ms, [],
+                          table_keywords={'bob': DELKW},
+                          column_keywords={'STATE_ID': {'bob': DELKW}})
+    dask.compute(writes)
+
+    with pt.table(ms, ack=False, readonly=True) as T:
+        assert 'bob' not in T.getkeywords()
+        assert 'bob' not in T.getcolkeywords("STATE_ID")
+

--- a/daskms/tests/test_ms_creation.py
+++ b/daskms/tests/test_ms_creation.py
@@ -286,5 +286,3 @@ def test_ms_create_and_update(Dataset, tmp_path, chunks):
                                   ms_datasets[1].DATA_DESC_ID.data])
         assert_array_equal(T.getcol("DATA"), ds_data)
         assert_array_equal(T.getcol("DATA_DESC_ID"), ds_ddid)
-
-

--- a/daskms/tests/test_ms_creation.py
+++ b/daskms/tests/test_ms_creation.py
@@ -288,35 +288,3 @@ def test_ms_create_and_update(Dataset, tmp_path, chunks):
         assert_array_equal(T.getcol("DATA_DESC_ID"), ds_ddid)
 
 
-def test_keywords(tmp_path):
-    from daskms.example_data import example_ms
-    from pprint import pprint
-
-    # Create an example MS
-    ms = example_ms()
-
-    with pt.table(ms, ack=False, readonly=True) as T:
-        desc = T._getdesc(actual=True)
-
-    datasets = xds_from_ms(ms)
-
-    for ds in datasets:
-        assert desc["_keywords_"] == ds.attrs['keywords']
-
-        for column, variable in ds.data_vars.items():
-            try:
-                keywords = variable.attrs['keywords']
-            except KeyError:
-                pass
-            else:
-                assert desc[column]['keywords'] == keywords
-
-    for ds in datasets:
-        del ds.attrs['keywords']
-        ds.attrs['keywords'] = {'pants': 'qux'}
-
-    writes = xds_to_table(datasets, ms, "STATE_ID")
-    dask.compute(writes)
-
-    with pt.table(ms, ack=False, readonly=True) as T:
-        assert T._getdesc(actual=True)["_keywords_"]['pants'] == 'qux'

--- a/daskms/tests/test_ms_creation.py
+++ b/daskms/tests/test_ms_creation.py
@@ -286,3 +286,37 @@ def test_ms_create_and_update(Dataset, tmp_path, chunks):
                                   ms_datasets[1].DATA_DESC_ID.data])
         assert_array_equal(T.getcol("DATA"), ds_data)
         assert_array_equal(T.getcol("DATA_DESC_ID"), ds_ddid)
+
+
+def test_keywords(tmp_path):
+    from daskms.example_data import example_ms
+    from pprint import pprint
+
+    # Create an example MS
+    ms = example_ms()
+
+    with pt.table(ms, ack=False, readonly=True) as T:
+        desc = T._getdesc(actual=True)
+
+    datasets = xds_from_ms(ms)
+
+    for ds in datasets:
+        assert desc["_keywords_"] == ds.attrs['keywords']
+
+        for column, variable in ds.data_vars.items():
+            try:
+                keywords = variable.attrs['keywords']
+            except KeyError:
+                pass
+            else:
+                assert desc[column]['keywords'] == keywords
+
+    for ds in datasets:
+        del ds.attrs['keywords']
+        ds.attrs['keywords'] = {'pants': 'qux'}
+
+    writes = xds_to_table(datasets, ms, "STATE_ID")
+    dask.compute(writes)
+
+    with pt.table(ms, ack=False, readonly=True) as T:
+        assert T._getdesc(actual=True)["_keywords_"]['pants'] == 'qux'

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -243,7 +243,7 @@ def test_multireadwrite(ms, group_cols, index_cols):
 
 def test_column_promotion(ms):
     """ Test singleton columns promoted to lists """
-    xds = xds_from_ms(ms, group_cols="SCAN_NUMBER", columns=("DATA"))
+    xds = xds_from_ms(ms, group_cols="SCAN_NUMBER", columns=("DATA",))
 
     for ds in xds:
         assert "DATA" in ds.data_vars

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -243,6 +243,12 @@ def update_datasets(table, datasets, columns, descriptor):
                              key=lambda t: ("ROWID" not in t[1].data_vars,
                                             t[0]))
 
+    # Merge keywords and add them to the table
+    keywords = {k: v for ds in datasets for k, v in ds.items()}
+
+    if len(keywords) > 0:
+        table_proxy.putkeywords(keywords)
+
     # Establish row orders for each dataset
     for di, ds in sorted_datasets:
         try:
@@ -476,6 +482,12 @@ def create_datasets(table_name, datasets, columns, descriptor):
     row_orders = add_row_order_factory(table_proxy, datasets)
     short_name = short_table_name(table_name)
     writes = []
+
+    # Merge keywords and add them to the table
+    keywords = {k: v for ds in datasets for k, v in ds.items()}
+
+    if len(keywords) > 0:
+        table_proxy.putkeywords(keywords).result()
 
     for di, (ds, row_order) in enumerate(zip(datasets, row_orders)):
         data_vars = ds.data_vars

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from collections import defaultdict
 import logging
 
 import dask
@@ -430,7 +429,6 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
             else:
                 full_dims = variable.dims
                 array = variable.data
-                attrs = variable.attrs
 
             args = [row_order, ("row",)]
 

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -478,7 +478,9 @@ def __write_datasets(table, table_proxy, datasets, columns, descriptor):
 
             writes.append(write_col.ravel())
 
-    table_keywords = {k: v for ds in datasets for k, v in ds.attrs.items()}
+    table_keywords = {k: v for ds in datasets
+                      for k, v in ds.attrs.get('keywords', {}).items()}
+
     table_proxy.submit(_put_keywords, WRITELOCK,
                        table_keywords, column_keywords).result()
 

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -244,7 +244,7 @@ def update_datasets(table, datasets, columns, descriptor):
                                             t[0]))
 
     # Merge keywords and add them to the table
-    keywords = {k: v for ds in datasets for k, v in ds.items()}
+    keywords = {k: v for ds in datasets for k, v in ds.attrs.items()}
 
     if len(keywords) > 0:
         table_proxy.putkeywords(keywords)
@@ -484,7 +484,7 @@ def create_datasets(table_name, datasets, columns, descriptor):
     writes = []
 
     # Merge keywords and add them to the table
-    keywords = {k: v for ds in datasets for k, v in ds.items()}
+    keywords = {k: v for ds in datasets for k, v in ds.attrs.items()}
 
     if len(keywords) > 0:
         table_proxy.putkeywords(keywords).result()

--- a/docs/tutorial/reads.rst
+++ b/docs/tutorial/reads.rst
@@ -327,3 +327,36 @@ vs a non-contiguous ordering:
 
 Internally, it is used to request or supply **ranges** of data from the Table
 when reading and writing, respectively.
+
+.. _read-keywords:
+
+Keywords
+~~~~~~~~
+
+It is possible to request both the table and column keywords:
+
+.. doctest::
+
+    >>> from daskms import xds_from_ms
+    >>> datasets, tabkw, colkw = xds_from_ms("~/data/TEST.MS",
+                                             table_keywords=True,
+                                             column_keywords=True)
+    >>> print(tabkw)
+    {'MS_VERSION': 2.0,
+     'ANTENNA': 'Table: ~/data/TEST.MS/ANTENNA',
+     'DATA_DESCRIPTION': 'Table: ~/data/TEST.MS/DATA_DESCRIPTION',
+     ...
+     'SPECTRAL_WINDOW': 'Table: ~/data/TEST.MS/SPECTRAL_WINDOW',
+     'STATE': 'Table: ~/data/TEST.MS/STATE'}
+
+    >>> print(colkw)
+    'UVW': {'QuantumUnits': ['m', 'm', 'm'],
+      'MEASINFO': {'type': 'uvw', 'Ref': 'J2000'}},
+      ...
+     'TIME': {'QuantumUnits': ['s'], 'MEASINFO': {'type': 'epoch', 'Ref': 'UTC'}},
+     'TIME_CENTROID': {'QuantumUnits': ['s'],
+      'MEASINFO': {'type': 'epoch', 'Ref': 'UTC'}},
+     'DATA': {'UNIT': 'Jy'},
+     'MODEL_DATA': {'CHANNEL_SELECTION': array([[ 0, 64]], dtype=int32)}}
+
+

--- a/docs/tutorial/writes.rst
+++ b/docs/tutorial/writes.rst
@@ -124,7 +124,7 @@ care is taken to ensure that
 
 1. Required columns are added.
 2. Required columns conform to the `Measurement Set v2.0 Specification
-<https://casacore.github.io/casacore-notes/229.html>`_.
+   <https://casacore.github.io/casacore-notes/229.html>`_.
 
 This means that, for example, if you have a UVW array
 with a non-standard shape ([4]) and type (float), the UVW column
@@ -155,14 +155,25 @@ Measurement Set table:
 
 .. doctest::
 
-    xds_to_table("test.ms", datasets, ["DATA", "BITFLAG"])
+    >>> xds_to_table("test.ms", datasets, ["DATA", "BITFLAG"])
 
 or when it ends with with ``::subtablename`` in the case of a subtable:
 
 .. doctest::
 
-    xds_to_table("test.ms::SPECTRAL_WINDOW", datasets, ["CHAN_FREQ"])
+    >>> xds_to_table("test.ms::SPECTRAL_WINDOW", datasets, ["CHAN_FREQ"])
 
 Respect the standard naming conventions and you'll be fine.
 
+
+Keywords
+~~~~~~~~
+
+Keywords can be added to the target table and columns:
+
+.. doctest::
+
+    >>> xds_to_table("test.ms", datasets, [],
+                     table_keywords={"foo":"bar"},
+                     column_keywords={"DATA": {"foo": "bar"}})
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
