### PR TITLE
Improve sub-table creation logic

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.2.0 (YYYY-MM-DD)
 ------------------
 
+* Improve sub-table creation logic (:pr:`59`)
 * Support table and column keywords (:pr:`58`)
 * Support concurrent access of multiple independent tables (:pr:`57`)
 * Fix WEIGHT_SPECTRUM schema dimensions (:pr:`56`)

--- a/daskms/descriptors/builder_factory.py
+++ b/daskms/descriptors/builder_factory.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import ast
 
-from daskms.utils import short_table_name
+from daskms.utils import table_path_split
 from daskms.table_schemas import SUBTABLES
 
 
@@ -89,19 +89,17 @@ def filename_builder_factory(filename):
     builder : :class:`daskms.descriptors.builder.AbtractDescriptorBuilder`
         Table Descriptor builder based on the filename
     """
-    canonical_name = short_table_name(filename)
+    _, table, subtable = table_path_split(filename)
 
     # Does this look like an MS
-    if canonical_name[-3:].upper().endswith('.MS'):
+    if not subtable and table[-3:].upper().endswith('.MS'):
         from daskms.descriptors.ms import MSDescriptorBuilder
         return MSDescriptorBuilder()
 
-    from daskms.descriptors.ms_subtable import MSSubTableDescriptorBuilder
-
     # Perhaps its an MS subtable?
-    for subtable in SUBTABLES:
-        if canonical_name.endswith(subtable):
-            return MSSubTableDescriptorBuilder(subtable)
+    if subtable in SUBTABLES:
+        from daskms.descriptors.ms_subtable import MSSubTableDescriptorBuilder
+        return MSSubTableDescriptorBuilder(subtable)
 
     # Just a standard CASA Table I guess
     from daskms.descriptors.builder import DefaultDescriptorBuilder

--- a/daskms/table_executor.py
+++ b/daskms/table_executor.py
@@ -6,10 +6,13 @@ from __future__ import print_function
 
 import logging
 import os
+from pathlib import Path
 from threading import Lock
 import weakref
 
 import concurrent.futures as cf
+
+from daskms.utils import table_path_split
 
 log = logging.getLogger(__name__)
 
@@ -75,13 +78,5 @@ def executor_key(table_name):
     """
 
     # Remove any path separators
-    table_name = table_name.rstrip(os.sep)
-
-    splits = table_name.split('::')
-
-    # Its a just a straightforward table/MS
-    if len(splits) == 1:
-        return table_name
-    # Sub-table. Return path bits without it (i.e the main table)
-    else:
-        return '::'.join(splits[:-1]).rstrip(os.sep)
+    root, table_name, subtable = table_path_split(table_name)
+    return str(Path(root, table_name))

--- a/daskms/table_executor.py
+++ b/daskms/table_executor.py
@@ -5,7 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
-import os
 from pathlib import Path
 from threading import Lock
 import weakref

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -254,6 +254,18 @@ class TableProxy(object, metaclass=TableProxyMetaClass):
         self._write = False
         self._writeable = table.iswritable()
 
+        should_be_writeable = not kwargs.get('readonly', True)
+
+        if self._writeable is False and should_be_writeable:
+            # NOTE(sjperkins)
+            # This seems to happen if you've opened a WSRT.MS with
+            # readonly=False, and then you try to open WSRT.MS::SUBTABLE
+            # with readonly=False.
+            # Solution is to open WSRT.MS/SUBTABLE to avoid the locking,
+            # which may introduce it's own set of issues
+            raise RuntimeError("%s was opened as readonly=False but "
+                               "table.iswritable()==False" % table.name())
+
     @property
     def executor_key(self):
         return self._ex_key

--- a/daskms/table_schemas.py
+++ b/daskms/table_schemas.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from collections import Mapping
 
-from daskms.utils import short_table_name
+from daskms.utils import table_path_split
 
 # Measurement Set sub-tables
 SUBTABLES = ("ANTENNA", "DATA_DESCRIPTION", "DOPPLER",
@@ -115,12 +115,13 @@ _ALL_SCHEMAS["TABLE"] = {}
 
 def infer_table_type(table_name):
     """ Guess the schema from the table name """
-    if table_name[-3:].upper().endswith(".MS"):
+    _, table, subtable = table_path_split(table_name)
+
+    if not subtable and table[-3:].upper().endswith(".MS"):
         return "MS"
 
-    for k in _SUBTABLE_SCHEMAS.keys():
-        if table_name.endswith('::' + k):
-            return k
+    if subtable in _SUBTABLE_SCHEMAS.keys():
+        return subtable
 
     return "TABLE"
 
@@ -148,7 +149,7 @@ def lookup_table_schema(table_name, lookup_str):
         :code:`{column: {'dims': (...)}}`.
     """
     if lookup_str is None:
-        table_type = infer_table_type(short_table_name(table_name))
+        table_type = infer_table_type(table_name)
 
         try:
             return _ALL_SCHEMAS[table_type]

--- a/daskms/tests/test_executor.py
+++ b/daskms/tests/test_executor.py
@@ -50,7 +50,6 @@ def test_executor():
     ('/home/moriarty/test.ms::FIELD', '/home/moriarty/test.ms'),
     ('/home/moriarty/test.ms::FIELD/', '/home/moriarty/test.ms'),
     ('/home/moriarty/test.ms::QUX/', '/home/moriarty/test.ms'),
-    ('/home/moriarty/::test.ms::QUX/', '/home/moriarty/::test.ms'),
 ])
 def test_executor_key(key, result):
     assert executor_key(key) == result

--- a/daskms/tests/test_ms_creation.py
+++ b/daskms/tests/test_ms_creation.py
@@ -53,7 +53,7 @@ def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types, sources):
     ddid_table_name = "::".join((ms_table_name, "DATA_DESCRIPTION"))
     pol_table_name = "::".join((ms_table_name, "POLARIZATION"))
     spw_table_name = "::".join((ms_table_name, "SPECTRAL_WINDOW"))
-    # SOURCE is not a standard MS sub-table
+    # SOURCE is an optional MS sub-table
     src_table_name = "::".join((ms_table_name, "SOURCE"))
 
     ms_datasets = []
@@ -234,7 +234,7 @@ def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types, sources):
             assert_array_equal(S.getcol("DIRECTION", startrow=r, nrow=1),
                                [direction])
 
-    with pt.table(ms_path, ack=False) as T:
+    with pt.table(ms_table_name, ack=False) as T:
         # DATA_DESC_ID's are all the same shape
         assert_array_equal(T.getcol("DATA_DESC_ID"),
                            da.concatenate(all_data_desc_id))

--- a/daskms/tests/test_ms_creation.py
+++ b/daskms/tests/test_ms_creation.py
@@ -34,26 +34,34 @@ else:
     [[9, 10, 11, 12], [5, 8]],
     [[5, 6, 7, 8], [9, 12]]
 ])
+@pytest.mark.parametrize("sources", [
+    [("PKS-1934", [5.1461782, -1.11199629], [0.9*.856e9, 1.1*.856e9]),
+     ("3C286",  [3.53925792, 0.53248541], [0.8*.856e9, .856e9, 1.2*.856e9])],
+])
 @pytest.mark.parametrize("Dataset", [
     Dataset,
     pytest.param(xrDataset, marks=xarray_param_marks)
 ], ids=["daskms.Dataset", "xarray.Dataset"])
-def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types):
+def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types, sources):
     # Set up
     rs = np.random.RandomState(42)
 
     ms_path = tmp_path / "create.ms"
+
     ms_table_name = str(ms_path)
-    ant_table_name = str(ms_path / "ANTENNA")
-    ddid_table_name = str(ms_path / "DATA_DESCRIPTION")
-    pol_table_name = str(ms_path / "POLARIZATION")
-    spw_table_name = str(ms_path / "SPECTRAL_WINDOW")
+    ant_table_name = "::".join((ms_table_name, "ANTENNA"))
+    ddid_table_name = "::".join((ms_table_name, "DATA_DESCRIPTION"))
+    pol_table_name = "::".join((ms_table_name, "POLARIZATION"))
+    spw_table_name = "::".join((ms_table_name, "SPECTRAL_WINDOW"))
+    # SOURCE is not a standard MS sub-table
+    src_table_name = "::".join((ms_table_name, "SOURCE"))
 
     ms_datasets = []
     ant_datasets = []
     ddid_datasets = []
     pol_datasets = []
     spw_datasets = []
+    src_datasets = []
 
     # For comparison
     all_data_desc_id = []
@@ -72,6 +80,20 @@ def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types):
         'NAME': (("row",), da.from_array(names, chunks=na)),
     })
     ant_datasets.append(ds)
+
+    # Create SOURCE datasets
+    for s, (name, direction, rest_freq) in enumerate(sources):
+        dask_num_lines = da.full((1,), len(rest_freq), dtype=np.int32)
+        dask_direction = da.asarray(direction)[None, :]
+        dask_rest_freq = da.asarray(rest_freq)[None, :]
+        dask_name = da.asarray(np.asarray([name], dtype=np.object))
+        ds = Dataset({
+            "NUM_LINES": (("row",), dask_num_lines),
+            "NAME": (("row",), dask_name),
+            "REST_FREQUENCY": (("row", "line"), dask_rest_freq),
+            "DIRECTION": (("row", "dir"), dask_direction),
+            })
+        src_datasets.append(ds)
 
     # Create POLARISATION datasets.
     # Dataset per output row required because column shapes are variable
@@ -143,8 +165,10 @@ def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types):
     pol_writes = xds_to_table(pol_datasets, pol_table_name, columns="ALL")
     spw_writes = xds_to_table(spw_datasets, spw_table_name, columns="ALL")
     ddid_writes = xds_to_table(ddid_datasets, ddid_table_name, columns="ALL")
+    source_writes = xds_to_table(src_datasets, src_table_name, columns="ALL")
 
-    dask.compute(ms_writes, ant_writes, pol_writes, spw_writes, ddid_writes)
+    dask.compute(ms_writes, ant_writes, pol_writes,
+                 spw_writes, ddid_writes, source_writes)
 
     # Check ANTENNA table correctly created
     with pt.table(ant_table_name, ack=False) as A:
@@ -201,7 +225,16 @@ def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types):
 
         assert set(D.colnames()) == set(required_columns)
 
-    with pt.table(str(ms_path), ack=False) as T:
+    with pt.table(src_table_name, ack=False) as S:
+        for r, (name, direction, rest_freq) in enumerate(sources):
+            assert_array_equal(S.getcol("NAME", startrow=r, nrow=1)[0],
+                               [name])
+            assert_array_equal(S.getcol("REST_FREQUENCY", startrow=r, nrow=1),
+                               [rest_freq])
+            assert_array_equal(S.getcol("DIRECTION", startrow=r, nrow=1),
+                               [direction])
+
+    with pt.table(ms_path, ack=False) as T:
         # DATA_DESC_ID's are all the same shape
         assert_array_equal(T.getcol("DATA_DESC_ID"),
                            da.concatenate(all_data_desc_id))

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -4,9 +4,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+from pathlib import Path
+import platform
+
 import pytest
 
-from daskms.utils import promote_columns
+from daskms.utils import promote_columns, table_path_split
 
 
 @pytest.mark.parametrize("columns", [["TIME", "ANTENNA1"]])
@@ -23,3 +27,30 @@ def test_promotion(columns, default):
 
     # None gives us the default
     assert promote_columns(None, default) == default
+
+
+_root_path = Path("C:/" if platform.system() == "Windows" else os.sep,
+                  "home", "moriarty")
+
+
+@pytest.mark.parametrize("path, root, table, subtable", [
+    # Table access
+    (_root_path / "test.ms",
+     _root_path, "test.ms", ""),
+    (_root_path / "test.ms{s}".format(s=os.sep),
+     _root_path, "test.ms", ""),
+    (_root_path / "test.ms{s}{s}".format(s=os.sep),
+     _root_path, "test.ms", ""),
+    # Indirect subtable access
+    (_root_path / "test.ms::SOURCE",
+     _root_path, "test.ms", "SOURCE"),
+    (_root_path / "test.ms::SOURCE{s}".format(s=os.sep),
+     _root_path, "test.ms", "SOURCE"),
+    # Direct subtable access
+    (_root_path / "test.ms" / "SOURCE",
+     _root_path / "test.ms", "SOURCE", ""),
+    (_root_path / "test.ms" / "SOURCE{s}".format(s=os.sep),
+     _root_path / "test.ms", "SOURCE", "")
+])
+def test_table_path_split(path, root, table, subtable):
+    assert (str(root), table, subtable) == table_path_split(path)

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -53,4 +53,4 @@ _root_path = Path("C:/" if platform.system() == "Windows" else os.sep,
      _root_path / "test.ms", "SOURCE", "")
 ])
 def test_table_path_split(path, root, table, subtable):
-    assert (str(root), table, subtable) == table_path_split(path)
+    assert (root, table, subtable) == table_path_split(path)

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -5,7 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
-import os
 from pathlib import Path
 import time
 
@@ -48,24 +47,6 @@ def promote_columns(columns, default):
         return [columns]
 
     raise TypeError("'columns' must be a string or a list of strings")
-
-
-def short_table_name(table_name):
-    """
-    Returns the last part
-
-    Parameters
-    ----------
-    table_name : str
-        CASA table path
-
-    Returns
-    -------
-    str
-        Shortened path
-
-    """
-    return os.path.split(table_name.rstrip(os.sep))[1]
 
 
 def table_path_split(path):

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import logging
 import os
+from pathlib import Path
 import time
 
 log = logging.getLogger(__name__)
@@ -65,6 +66,17 @@ def short_table_name(table_name):
 
     """
     return os.path.split(table_name.rstrip(os.sep))[1]
+
+
+def table_path_split(path):
+    """ Splits a table path into a (root, table, subtable) tuple """
+    if not isinstance(path, Path):
+        path = Path(path)
+
+    root = str(path.parent)
+    table_name, _, subtable = path.name.partition("::")
+
+    return root, table_name, subtable
 
 
 def group_cols_str(group_cols):

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -73,7 +73,7 @@ def table_path_split(path):
     if not isinstance(path, Path):
         path = Path(path)
 
-    root = str(path.parent)
+    root = path.parent
     table_name, _, subtable = path.name.partition("::")
 
     return root, table_name, subtable

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -20,7 +20,7 @@ from daskms.ordering import row_run_factory
 from daskms.table import table_exists
 from daskms.table_executor import executor_key
 from daskms.table_proxy import TableProxy, WRITELOCK
-from daskms.utils import short_table_name, table_path_split
+from daskms.utils import table_path_split
 
 
 log = logging.getLogger(__name__)
@@ -397,7 +397,8 @@ def add_row_order_factory(table_proxy, datasets):
 
 def _write_datasets(table, table_proxy, datasets, columns, descriptor,
                     table_keywords, column_keywords):
-    table_name = short_table_name(table)
+    _, table_name, subtable = table_path_split(table)
+    table_name = '::'.join((table_name, subtable)) if subtable else table_name
     writes = []
     row_orders = []
 

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -171,7 +171,7 @@ def _create_table(table_name, datasets, columns, descriptor):
     table_desc, dminfo = builder.execute(datasets)
 
     root, table, subtable = table_path_split(table_name)
-    table_path = Path(root, table)
+    table_path = root / table
 
     from daskms.descriptors.ms import MSDescriptorBuilder
     from daskms.descriptors.ms_subtable import MSSubTableDescriptorBuilder

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -5,8 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
-import os
-from pathlib import Path
 
 import dask
 import dask.array as da

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -5,6 +5,8 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
+import os
+from pathlib import Path
 
 import dask
 import dask.array as da
@@ -20,7 +22,7 @@ from daskms.ordering import row_run_factory
 from daskms.table import table_exists
 from daskms.table_executor import executor_key
 from daskms.table_proxy import TableProxy, WRITELOCK
-from daskms.utils import short_table_name
+from daskms.utils import short_table_name, table_path_split
 
 
 log = logging.getLogger(__name__)
@@ -158,39 +160,65 @@ def descriptor_builder(table, descriptor):
         return string_builder_factory(descriptor)
 
 
-def _create_table(table, datasets, columns, descriptor):
-    builder = descriptor_builder(table, descriptor)
+def _writable_table_proxy(table_name):
+    return TableProxy(pt.table, table_name, ack=False,
+                      readonly=False, lockoptions='user',
+                      __executor_key__=executor_key(table_name))
+
+
+def _create_table(table_name, datasets, columns, descriptor):
+    builder = descriptor_builder(table_name, descriptor)
     table_desc, dminfo = builder.execute(datasets)
+
+    root, table, subtable = table_path_split(table_name)
+    table_path = Path(root, table)
 
     from daskms.descriptors.ms import MSDescriptorBuilder
     from daskms.descriptors.ms_subtable import MSSubTableDescriptorBuilder
 
-    if isinstance(builder, MSDescriptorBuilder):
+    if not subtable and isinstance(builder, MSDescriptorBuilder):
+        table_path = str(table_path)
+
         # Create the MS
-        with pt.default_ms(table, tabdesc=table_desc, dminfo=dminfo):
-            pass
-    elif isinstance(builder, MSSubTableDescriptorBuilder):
-        # Create the MS subtable
-        subtable = builder.subtable
-        create_dir = short_table_name(table).rstrip(subtable)
-        with pt.default_ms_subtable(builder.subtable, create_dir,
-                                    tabdesc=table_desc, dminfo=dminfo):
-            pass
-    else:
-        # Create the table
-        with pt.table(table, table_desc, dminfo=dminfo, ack=False):
+        with pt.default_ms(table_path, tabdesc=table_desc, dminfo=dminfo):
             pass
 
-    return TableProxy(pt.table, table, ack=False,
-                      readonly=False, lockoptions='user',
-                      __executor_key__=executor_key(table))
+        return _writable_table_proxy(table_path)
+    elif subtable:
+        # NOTE(sjperkins)
+        # Recreate the subtable path with OS separator components
+        # This avoids accessing the subtable via the main table
+        # (e.g. WSRT.MS::SOURCE)
+        # which can cause lock issues as the subtables seemingly
+        # inherit the parent table lock
+        subtable_path = str(table_path / subtable)
+
+        # Create the subtable
+        if isinstance(builder, MSSubTableDescriptorBuilder):
+            with pt.default_ms_subtable(subtable, subtable_path,
+                                        tabdesc=table_desc, dminfo=dminfo):
+                pass
+        else:
+            with pt.table(subtable, table_desc, dminfo, ack=False):
+                pass
+
+        # Add subtable to the main table
+        table_proxy = _writable_table_proxy(str(table_path))
+        table_proxy.putkeywords({subtable: "Table: " + subtable_path}).result()
+        del table_proxy
+
+        # Return TableProxy
+        return _writable_table_proxy(subtable_path)
+    else:
+        # Create the table
+        with pt.table(str(table_path), table_desc, dminfo=dminfo, ack=False):
+            pass
+
+        return _writable_table_proxy(str(table_path))
 
 
 def _updated_table(table, datasets, columns, descriptor):
-    table_proxy = TableProxy(pt.table, table, ack=False,
-                             readonly=False, lockoptions='user',
-                             __executor_key__=executor_key(table))
-
+    table_proxy = _writable_table_proxy(table)
     table_columns = set(table_proxy.colnames().result())
     missing = set(columns) - table_columns
 
@@ -499,8 +527,10 @@ def write_datasets(table, datasets, columns, descriptor=None,
 
     # If ALL is requested
     if columns == "ALL":
-        columns = set.union(*(set(ds.data_vars.keys()) for ds in datasets))
-        columns = list(sorted(columns))
+        columns = list(set(ds.data_vars.keys()) for ds in datasets)
+
+        if len(columns) > 0:
+            columns = list(sorted(set.union(*columns)))
 
     if not table_exists(table):
         table_proxy = _create_table(table, datasets, columns, descriptor)

--- a/docs/tutorial/reads.rst
+++ b/docs/tutorial/reads.rst
@@ -96,6 +96,37 @@ Access array attribute dictionary:
                   'MEASINFO': {'type': 'epoch', 'Ref': 'UTC'}}}
 
 
+.. _read-opening-sub-tables:
+
+Opening Sub-tables
+~~~~~~~~~~~~~~~~~~
+
+CASA Tables can also have sub-tables associated with them.
+For example, the Measurement Set has ANTENNA, SPECTRAL_WINDOW
+and DATA_DESCRIPTION sub-tables.
+
+``::``, the traditional scope operator used by
+`Taql <https://casacore.github.io/casacore-notes/199.html>`_
+used to reference the sub-tables of a table, is
+understood by python-casacore and dask-ms.
+The following convention specifies that the ``ANTENNA`` sub-table
+of ``TEST.MS`` should be opened:
+
+.. doctest::
+
+    >>> ant_datasets = xds_from_table("~/data/TEST.MS::ANTENNA")
+
+It is recommended that the ``TEST.MS::ANTENNA`` convention be
+followed as it makes the link between the table and sub-table clear to dask-ms.
+
+Alternatively, as sub-tables are simply stored as sub-directories
+of the main table, it is also possible to reference them as follows:
+
+.. doctest::
+
+    >>> ant_datasets = xds_from_table("~/data/TEST.MS/ANTENNA")
+
+
 Grouping
 ~~~~~~~~
 

--- a/docs/tutorial/writes.rst
+++ b/docs/tutorial/writes.rst
@@ -155,16 +155,48 @@ Measurement Set table:
 
 .. doctest::
 
-    >>> xds_to_table("test.ms", datasets, ["DATA", "BITFLAG"])
+    >>> xds_to_table(datasets, "test.ms", ["DATA", "BITFLAG"])
 
 or when it ends with with ``::subtablename`` in the case of a subtable:
 
 .. doctest::
 
-    >>> xds_to_table("test.ms::SPECTRAL_WINDOW", datasets, ["CHAN_FREQ"])
+    >>> xds_to_table(datasets, "test.ms::SPECTRAL_WINDOW", ["CHAN_FREQ"])
 
 Respect the standard naming conventions and you'll be fine.
 
+
+Creating Sub-tables
+~~~~~~~~~~~~~~~~~~~
+
+It is possible for sub-tables to be added to a table.
+For example, the SOURCE table is an optional table that may or may not
+be present on the Measurement Set
+
+The following convention specifies that the ``SOURCE`` sub-table
+of ``TEST.MS`` should be created:
+
+.. doctest::
+
+    >>> writes = xds_to_table(source_dataset,
+                              "~/data/TEST.MS::SOURCE",
+                              columns="ALL")
+
+``xds_to_table`` will also created the ``"Table: ~/data/TEST.MS/SOURCE"``
+keyword in ``TEST.MS`` linking it with the ``SOURCE`` sub-table.
+
+.. warning::
+
+    As discussed in :ref:`read-opening-sub-tables`, it is advisable to use the
+    `::` scope operator so that dask-ms understands the link between the
+    main table and the sub-table. The following will create a SOURCE table
+    but will not create a link between the table and the sub-table:
+
+    .. doctest::
+
+        >>> writes = xds_to_table(source_dataset,
+                                  "~/data/TEST.MS/SOURCE",
+                                  columns="ALL")
 
 Keywords
 ~~~~~~~~
@@ -173,7 +205,7 @@ Keywords can be added to the target table and columns:
 
 .. doctest::
 
-    >>> xds_to_table("test.ms", datasets, [],
+    >>> xds_to_table(datasets, "test.ms", [],
                      table_keywords={"foo":"bar"},
                      column_keywords={"DATA": {"foo": "bar"}})
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
