### PR TITLE
Fix and test non-MS subtable creation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,8 +5,8 @@ History
 0.2.0 (YYYY-MM-DD)
 ------------------
 
-* Fix a test non-standard sub-table creation (:pr:`60`)
-* Improve sub-table creation logic (:pr:`59`)
+* Fix and test non-standard sub-table creation (:pr:`60`)
+* Improve sub-table creation logic (:pr:`59`, :pr:`60`)
 * Support table and column keywords (:pr:`58`)
 * Support concurrent access of multiple independent tables (:pr:`57`)
 * Fix WEIGHT_SPECTRUM schema dimensions (:pr:`56`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.2.0 (YYYY-MM-DD)
 ------------------
 
+* Fix a test non-standard sub-table creation (:pr:`60`)
 * Improve sub-table creation logic (:pr:`59`)
 * Support table and column keywords (:pr:`58`)
 * Support concurrent access of multiple independent tables (:pr:`57`)

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -197,7 +197,7 @@ def _create_table(table_name, datasets, columns, descriptor):
                                         tabdesc=table_desc, dminfo=dminfo):
                 pass
         else:
-            with pt.table(subtable, table_desc, dminfo, ack=False):
+            with pt.table(subtable_path, table_desc, dminfo=dminfo, ack=False):
                 pass
 
         # Add subtable to the main table


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
