### PR TITLE
Remove keywords from variable attributes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.2.1 (YYYY-MM-DD)
+------------------
+
+* Remove keywords from variable attributes (:pr:`64`)
+
 0.2.0 (2019-09-30)
 ------------------
 

--- a/daskms/columns.py
+++ b/daskms/columns.py
@@ -93,7 +93,7 @@ class ColumnMetadataError(Exception):
 
 
 ColumnMetadata = namedtuple("ColumnMetadata",
-                            ["shape", "dims", "chunks", "dtype", "attrs"])
+                            ["shape", "dims", "chunks", "dtype"])
 
 
 def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
@@ -228,15 +228,7 @@ def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
                                   "dim_chunks '%s' do not agree." %
                                   (shape, dims, dim_chunks))
 
-    # Place table keywords in attributes
-    try:
-        keywords = coldesc['keywords']
-    except KeyError:
-        attrs = {}
-    else:
-        attrs = {} if len(keywords) == 0 else {"keywords": keywords}
-
-    return ColumnMetadata(shape, dims, dim_chunks, dtype, attrs)
+    return ColumnMetadata(shape, dims, dim_chunks, dtype)
 
 
 def dim_extents_array(dim, chunks):

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -252,7 +252,7 @@ def _dataset_variable_factory(table_proxy, table_schema, select_cols,
                                   dtype=meta.dtype)
 
         # Assign into variable and dimension dataset
-        dataset_vars[column] = (full_dims, dask_array, meta.attrs)
+        dataset_vars[column] = (full_dims, dask_array)
 
     return dataset_vars
 


### PR DESCRIPTION
This is a left over artifact from a previous keyword reading strategy.
Should have been removed in https://github.com/ska-sa/dask-ms/pull/58.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
