### PR TITLE
Fix stress test

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.2.1 (YYYY-MM-DD)
 ------------------
 
+* Fix stress test (:pr:`65`)
 * Remove keywords from variable attributes (:pr:`64`)
 
 0.2.0 (2019-09-30)

--- a/daskms/tests/test_stress.py
+++ b/daskms/tests/test_stress.py
@@ -27,7 +27,8 @@ def test_stress(big_ms, iterations, chunks):
     writes = []
 
     for i in range(iterations):
-        nds = ds.assign(TIME=ds.TIME + i, DATA=ds.DATA + i)
+        nds = ds.assign(TIME=(("row",), ds.TIME.data + i),
+                        DATA=(("row", "chan", "corr"), ds.DATA.data + i))
         writes.append(write_datasets(big_ms, nds, ["TIME", "DATA"]))
 
     dask.compute(writes)


### PR DESCRIPTION
Internal daskms.dataset.Variable class doesn't support operations like an xarrayms Variable.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
