### PR TITLE
Introduce appropriate space in taql where clause

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.2.2 (YYYY-MM-DD)
+------------------
+* Fix spacing in TAQL WHERE queries (:pr:`68`)
+
+
 0.2.1 (2019-10-23)
 ------------------
 

--- a/daskms/ordering.py
+++ b/daskms/ordering.py
@@ -68,12 +68,12 @@ def _sorted_rows(taql_proxy, startrow, nrow):
 
 def ordering_taql(table_proxy, index_cols, taql_where=''):
     select = select_clause(["ROWID() as __tablerow__"])
-    orderby = orderby_clause(index_cols)
+    orderby = "\n" + orderby_clause(index_cols)
 
     if taql_where != '':
-        taql_where = "WHERE\n\t%s" % taql_where
+        taql_where = "\nWHERE\n\t%s" % taql_where
 
-    query = "%s\nFROM\n\t$1\n%s%s" % (select, orderby, taql_where)
+    query = "%s\nFROM\n\t$1%s%s" % (select, taql_where, orderby)
 
     return TableProxy(taql_factory, query, tables=[table_proxy],
                       __executor_key__=table_proxy.executor_key)

--- a/daskms/tests/test_ordering.py
+++ b/daskms/tests/test_ordering.py
@@ -29,6 +29,97 @@ def table_proxy(ms):
 @pytest.mark.parametrize("index_cols", [
     ["TIME", "ANTENNA1", "ANTENNA2"]],
     ids=index_cols_str)
+def test_ordering_query_taql_where_strings(ms, group_cols, index_cols):
+    taql = group_ordering_taql(table_proxy(ms), group_cols, index_cols,
+                               taql_where="ANTENNA1 != ANTENNA2")
+    assert taql._args[0].replace("\t", " "*4) == (
+                    "SELECT\n"
+                    "    FIELD_ID,\n"
+                    "    SCAN_NUMBER,\n"
+                    "    GAGGR(TIME) as GROUP_TIME,\n"
+                    "    GAGGR(ANTENNA1) as GROUP_ANTENNA1,\n"
+                    "    GAGGR(ANTENNA2) as GROUP_ANTENNA2,\n"
+                    "    GROWID() AS __tablerow__,\n"
+                    "    GCOUNT() as __tablerows__,\n"
+                    "    GROWID()[0] as __firstrow__\n"
+                    "FROM\n"
+                    "    $1\n"
+                    "GROUPBY\n"
+                    "    FIELD_ID,\n"
+                    "    SCAN_NUMBER\n"
+                    "HAVING\n"
+                    "    ANTENNA1 != ANTENNA2")
+
+    taql = group_ordering_taql(table_proxy(ms), group_cols, index_cols)
+    assert taql._args[0].replace("\t", " "*4) == (
+                    "SELECT\n"
+                    "    FIELD_ID,\n"
+                    "    SCAN_NUMBER,\n"
+                    "    GAGGR(TIME) as GROUP_TIME,\n"
+                    "    GAGGR(ANTENNA1) as GROUP_ANTENNA1,\n"
+                    "    GAGGR(ANTENNA2) as GROUP_ANTENNA2,\n"
+                    "    GROWID() AS __tablerow__,\n"
+                    "    GCOUNT() as __tablerows__,\n"
+                    "    GROWID()[0] as __firstrow__\n"
+                    "FROM\n"
+                    "    $1\n"
+                    "GROUPBY\n"
+                    "    FIELD_ID,\n"
+                    "    SCAN_NUMBER")
+
+    taql = group_ordering_taql(table_proxy(ms), group_cols, [])
+    assert taql._args[0].replace("\t", " "*4) == (
+                    "SELECT\n"
+                    "    FIELD_ID,\n"
+                    "    SCAN_NUMBER,\n"
+                    "    GROWID() AS __tablerow__,\n"
+                    "    GCOUNT() as __tablerows__,\n"
+                    "    GROWID()[0] as __firstrow__\n"
+                    "FROM\n"
+                    "    $1\n"
+                    "GROUPBY\n"
+                    "    FIELD_ID,\n"
+                    "    SCAN_NUMBER")
+
+    taql = ordering_taql(table_proxy(ms), index_cols,
+                         taql_where="ANTENNA1 != ANTENNA2")
+    assert taql._args[0].replace("\t", " "*4) == (
+                    "SELECT\n"
+                    "    ROWID() as __tablerow__\n"
+                    "FROM\n"
+                    "    $1\n"
+                    "WHERE\n"
+                    "    ANTENNA1 != ANTENNA2\n"
+                    "ORDERBY\n"
+                    "    TIME,\n"
+                    "    ANTENNA1,\n"
+                    "    ANTENNA2")
+
+    taql = ordering_taql(table_proxy(ms), index_cols)
+    assert taql._args[0].replace("\t", " "*4) == (
+                    "SELECT\n"
+                    "    ROWID() as __tablerow__\n"
+                    "FROM\n"
+                    "    $1\n"
+                    "ORDERBY\n"
+                    "    TIME,\n"
+                    "    ANTENNA1,\n"
+                    "    ANTENNA2")
+
+    taql = ordering_taql(table_proxy(ms), [])
+    assert taql._args[0].replace("\t", " "*4) == (
+                    "SELECT\n"
+                    "    ROWID() as __tablerow__\n"
+                    "FROM\n"
+                    "    $1\n")
+
+
+@pytest.mark.parametrize("group_cols", [
+    ["FIELD_ID", "SCAN_NUMBER"]],
+    ids=group_cols_str)
+@pytest.mark.parametrize("index_cols", [
+    ["TIME", "ANTENNA1", "ANTENNA2"]],
+    ids=index_cols_str)
 def test_ordering_multiple_groups(ms, group_cols, index_cols):
     group_taql = group_ordering_taql(table_proxy(ms), group_cols, index_cols)
     assert_liveness(2, 1)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
