### PR TITLE
Create datasets representing write operations

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-* xarray-ms version:
+* dask-ms version:
 * Python version:
 * Operating System:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 - [ ] Tests added / passed
 
   ```bash
-  $ py.test -v -s xarrayms/tests
+  $ py.test -v -s daskms/tests
   ```
 
   If the pep8 tests fail, the quickest way to correct
@@ -10,9 +10,9 @@
 
   ```
   $ pip install -U autopep8 flake8 pycodestyle
-  $ autopep8 -r -i xarrayms
-  $ flake8 xarrayms
-  $ pycodestyle xarrayms
+  $ autopep8 -r -i daskms
+  $ flake8 daskms
+  $ pycodestyle daskms
   ```
 
 - [ ] Fully documented, including `HISTORY.rst` for all changes

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.2.3 (YYYY-MM-DD)
+------------------
+* Produce write datasets rather a single concatenated dask array (:pr:`70`)
+
+
 0.2.2 (2019-10-25)
 ------------------
 * Fix spacing in TAQL WHERE queries (:pr:`68`)

--- a/daskms/dask_ms.py
+++ b/daskms/dask_ms.py
@@ -26,11 +26,11 @@ log = logging.getLogger(__name__)
 def xds_to_table(xds, table_name, columns, descriptor=None,
                  table_keywords=None, column_keywords=None):
     """
-    Generates a dask array representing a series of writes from the
+    Generates a list of Datasets representing a write operations from the
     specified arrays in :class:`xarray.Dataset`'s into
     the CASA table columns specified by ``table_name`` and ``columns``.
     This is lazy operation -- it is only execute when a :meth:`dask.compute`
-    or :meth:`dask.array.Array.compute` method is called.
+    or :meth:`xarray.Dataset.compute` method is called.
 
     Parameters
     ----------
@@ -70,9 +70,9 @@ def xds_to_table(xds, table_name, columns, descriptor=None,
 
     Returns
     -------
-    writes : :class:`dask.array.Array`
-        dask array representing the write to the
-        dataset.
+    write_datasets : list of :class:`xarray.Dataset`
+        Datasets containing arrays representing write operations
+        into a CASA Table
     """
 
     # Promote dataset to a list

--- a/daskms/tests/test_ms_creation.py
+++ b/daskms/tests/test_ms_creation.py
@@ -86,7 +86,7 @@ def test_ms_create(Dataset, tmp_path, chunks, num_chans, corr_types, sources):
         dask_num_lines = da.full((1,), len(rest_freq), dtype=np.int32)
         dask_direction = da.asarray(direction)[None, :]
         dask_rest_freq = da.asarray(rest_freq)[None, :]
-        dask_name = da.asarray(np.asarray([name], dtype=np.object))
+        dask_name = da.asarray(np.asarray([name], dtype=np.object), chunks=1)
         ds = Dataset({
             "NUM_LINES": (("row",), dask_num_lines),
             "NAME": (("row",), dask_name),


### PR DESCRIPTION
Previously, a single dask array was returned representing writes from arrays to CASA columns.
Now, Datasets, which are dask collections and can be understood by the dask.compute/persist are returned instead.


- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
