### PR TITLE
Read-lock TAQL row ordering table by default

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.3 (YYYY-MM-DD)
 ------------------
+* Explicitly read-lock TAQL row reference table (:pr:`74`)
 * Produce write datasets rather a single concatenated dask array
   (:pr:`70`, :pr:`72`)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.3 (YYYY-MM-DD)
 ------------------
-* Explicitly read-lock TAQL row reference table (:pr:`74`)
+* Read-lock TAQL row reference table by default (:pr:`74`)
 * Produce write datasets rather a single concatenated dask array
   (:pr:`70`, :pr:`72`)
 

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -187,7 +187,7 @@ def taql_factory(query, style='Python', tables=[]):
     tables = [t._table_future.result() for t in tables]
 
     for t in tables:
-        t.lock()
+        t.lock(write=False)
 
     try:
         return pt.taql(query, style=style, tables=tables)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
