### PR TITLE
Only aggressively log when the log level is DEBUG

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.3 (YYYY-MM-DD)
 ------------------
+* Only log aggressively when the log level is DEBUG (:pr:`76`)
 * Read-lock TAQL row reference table by default (:pr:`74`)
 * Produce write datasets rather a single concatenated dask array
   (:pr:`70`, :pr:`72`)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -219,8 +219,10 @@ def _dataset_variable_factory(table_proxy, table_schema, select_cols,
         try:
             meta = column_metadata(column, table_proxy, table_schema,
                                    chunks, exemplar_row)
-        except ColumnMetadataError:
-            log.warning("Ignoring column: '%s'", column, exc_info=True)
+        except ColumnMetadataError as e:
+            exc_info = logging.DEBUG >= log.getEffectiveLevel()
+            log.warning("Ignoring '%s': %s", column, e,
+                        exc_info=exc_info)
             continue
 
         full_dims = ("row",) + meta.dims


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
