### PR TITLE
Document python-casacore installation process

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.2.4 (YYYY-MM-DD)
+------------------
+* Document python-casacore install process (:pr:`80`)
+
 0.2.3 (2019-12-09)
 ------------------
 * Remove \_\_future\_\_ import (:pr:`79`)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,25 @@ The full list of packages are available here:
 - https://github.com/casacore/casacore#requirements
 - https://github.com/casacore/python-casacore#from-source
 
-casacore Measures data
-~~~~~~~~~~~~~~~~~~~~~~
+Updating casacore Measures data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please complete me
+python-casacore wraps an internal casacore Measurement system that is used
+to relate astronomical objects to each other in space and time.
+Measures data is frequently updated and casacore/python-casacore
+will complain if it is out of date.
+
+The measures data can be downloaded at the location specified here:
+
+- https://github.com/casacore/casacore#obtaining-measures-data
+
+Uncompress the measures data to some appropriate location, such
+as ``~/opt/casacore/data`` and point your python-casacore installation
+to it by creating a ``.casarc`` file in your home directory
+with the following contents:
+
+.. code-block::
+
+    measures.directory: ~/opt/casacore/data/
+
+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,29 +23,35 @@ you through the process.
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
 
 
-From sources
-------------
+python-casacore
+---------------
 
-The sources for dask-ms can be downloaded from the `Github repo`_.
+python-casacore is a `dependency <https://github.com/ska-sa/dask-ms/blob/83b09651f35b78b5e9f0ded3712bb7e10c496d1c/setup.py#L27_>`_
+of dask-ms, used to access CASA tables. This means that when we do the following:
 
-You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/ska-sa/dask-ms
-
-Or download the `tarball`_:
-
-.. code-block:: console
-
-    $ curl  -OL https://github.com/ska-sa/dask-ms/tarball/master
-
-Once you have a copy of the source, you can install it with:
-
-.. code-block:: console
-
-    $ python setup.py install
+    $ pip install dask-ms
 
 
-.. _Github repo: https://github.com/ska-sa/dask-ms
-.. _tarball: https://github.com/ska-sa/dask-ms/tarball/master
+pip will download python-casacore and try to install it.
+There are binary wheels for versions of python-casacore >= 3.1.1 which,
+in general, make the installation process trivial.
+
+*However*, pip will attempt to build earlier versions from source.
+
+Building python-casacore from source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For pip to build python-casacore from source, the appropriate
+C and C++ libraries must be installed otherwise this build process will fail.
+The full list of packages are available here:
+
+- https://github.com/casacore/casacore#requirements
+- https://github.com/casacore/python-casacore#from-source
+
+casacore Measures data
+~~~~~~~~~~~~~~~~~~~~~~
+
+Please complete me


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
