### PR TITLE
Upgrade to python-casacore 3.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
+* Upgrade to python-casacore 3.2 (:pr:`84`)
 * Re-introduce xarray handling in dataset.as_variable (:pr:`83`)
 * Explicitly require dask Arrays on write datasets (:pr:`83`)
 * Document python-casacore install process (:pr:`80`, :pr:`81`)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if not on_rtd:
     install_requires += [
         "numpy >= 1.14.0",
-        "python-casacore >= 3.0.0",
+        "python-casacore >= 3.2.0",
     ]
 
 


### PR DESCRIPTION
In order to take advantage of https://github.com/casacore/casacore/pull/974

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
