### PR TITLE
Improve MS structure inspection

### DIFF
--- a/daskms/ms_structure.py
+++ b/daskms/ms_structure.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+import os
+from os.path import join as pjoin
+
+import numpy as np
+import pyrap.tables as pt
+
+
+SUBTABLES = {
+    ("FEED", False): "NUM_RECEPTORS",
+    ("FIELD", False): "NUM_POLY",
+    ("POINTING", False): "NUM_POLY",
+    ("POLARIZATION", True): "NUM_CORR",
+    ("SOURCE", False): "NUM_LINES",
+    ("SPECTRAL_WINDOW", True): "NUM_CHAN"
+}
+
+
+def _inspect_subtables(ms):
+    for (subtable, required), num_column in SUBTABLES.items():
+        subtable_path = pjoin(ms, subtable)
+        subtable_name = "::".join((ms, subtable))
+
+        if not os.path.isdir(subtable_path):
+            if required:
+                raise ValueError("%s required but not present", subtable)
+
+            continue
+
+        with pt.table(subtable_name, ack=False, readonly=True) as T:
+            yield ((subtable, num_column), T.getcol(num_column))
+
+
+def inspect_ms(ms):
+    subtables = dict(_inspect_subtables(ms))
+
+    ddid_name = "::".join((ms, "DATA_DESCRIPTION"))
+
+    spw = subtables[("SPECTRAL_WINDOW", "NUM_CHAN")]
+    pol = subtables[("POLARIZATION", "NUM_CORR")]
+
+    with pt.table(ddid_name, ack=False, readonly=True) as T:
+        spw_id = T.getcol("SPECTRAL_WINDOW_ID")
+        pol_id = T.getcol("POLARIZATION_ID")
+
+        nchan = spw[spw_id]
+        ncorr = pol[pol_id]
+
+        ddid_shapes = np.stack([nchan, ncorr], axis=1)
+        return ddid_shapes
+
+
+

--- a/daskms/tests/test_ms_structure.py
+++ b/daskms/tests/test_ms_structure.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from daskms.ms_structure import inspect_ms
+
+
+def test_ms_structure():
+    print(inspect_ms("/home/sperkins/data/WSRT_multiple.MS_p0"))


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
