### PR TITLE
Cache and inline row run creation for table updates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
+* Cache and inline row runs in write operations (:pr:`96`)
 * Support getcolslice and putcolslice in TableProxy (:pr:`91`)
 * Use weakref.finalize to cleanup TableProxy and Executor objects (:pr:`89`)
 * Pickle Executor key argument (:pr:`88`)

--- a/daskms/tests/test_dataset.py
+++ b/daskms/tests/test_dataset.py
@@ -325,6 +325,8 @@ def test_dataset_multidim_string_column(tmp_path, chunks):
     np_names = np.array(name_list, dtype=np.object)
     names = da.from_array(np_names, chunks=(chunks['row'], np_names.shape[1]))
 
+    print(names)
+
     ds = Dataset({"POLARIZATION_TYPE": (("row", "xyz"), names)})
     table_name = str(tmp_path / "test.table")
     writes = write_datasets(table_name, ds, ["POLARIZATION_TYPE"])


### PR DESCRIPTION
Fixes #95 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
