### PR TITLE
Use WHERE rather than HAVING clause in group ordering TAQL

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
-* Warn if column is present in both group_cols and taql_where (:pr:`98`)
+* Use WHERE rather than HAVING clause in group ordering TAQL (:pr:`98`)
 * Cache and inline row runs in write operations (:pr:`96`)
 * Support getcolslice and putcolslice in TableProxy (:pr:`91`)
 * Use weakref.finalize to cleanup TableProxy and Executor objects (:pr:`89`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
+* Warn if column is present in both group_cols and taql_where (:pr:`98`)
 * Cache and inline row runs in write operations (:pr:`96`)
 * Support getcolslice and putcolslice in TableProxy (:pr:`91`)
 * Use weakref.finalize to cleanup TableProxy and Executor objects (:pr:`89`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
-* Warn if column is present in both group_cols and taql_where (:pr:`98`)
+* Fail if column is present in both group_cols and taql_where (:pr:`98`)
 * Cache and inline row runs in write operations (:pr:`96`)
 * Support getcolslice and putcolslice in TableProxy (:pr:`91`)
 * Use weakref.finalize to cleanup TableProxy and Executor objects (:pr:`89`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
-* Fail if column is present in both group_cols and taql_where (:pr:`98`)
+* Warn if column is present in both group_cols and taql_where (:pr:`98`)
 * Cache and inline row runs in write operations (:pr:`96`)
 * Support getcolslice and putcolslice in TableProxy (:pr:`91`)
 * Use weakref.finalize to cleanup TableProxy and Executor objects (:pr:`89`)

--- a/daskms/ordering.py
+++ b/daskms/ordering.py
@@ -182,9 +182,9 @@ def group_ordering_taql(table_proxy, group_cols, index_cols, taql_where=''):
         select = select_clause(group_cols + index_group_cols)
 
         if taql_where != '':
-            taql_where = "\nHAVING\n\t%s" % taql_where
+            taql_where = "\nWHERE\n\t%s" % taql_where
 
-        query = "%s\nFROM\n\t$1\n%s%s" % (select, groupby, taql_where)
+        query = "%s\nFROM\n\t$1%s\n%s" % (select, taql_where, groupby)
 
         return TableProxy(taql_factory, query, tables=[table_proxy],
                           __executor_key__=table_proxy.executor_key)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -297,11 +297,10 @@ class DatasetFactory(object):
 
         for column in self.group_cols:
             if column in self.taql_where:
-                raise ValueError("Column %s is present in both group_cols "
-                                 "and taql_where. This is unsupported "
-                                 "because dask-ms uses TAQL to group "
-                                 "datasets internally which conflicts "
-                                 "with user supplied TAQL" % column)
+                log.warning("Column %s is present in both group_cols "
+                            "and taql_where. This is unsupported "
+                            "and will cause dask-ms to behave unexpectedly.",
+                            column)
 
         if len(kwargs) > 0:
             raise ValueError("Unhandled kwargs: %s" % kwargs)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -295,6 +295,13 @@ class DatasetFactory(object):
         self.column_keywords = kwargs.pop('column_keywords', False)
         self.table_proxy = kwargs.pop('table_proxy', False)
 
+        for column in self.group_cols:
+            if column in self.taql_where:
+                log.warning("Column %s is present in both group_cols "
+                            "and taql_where. This is unsupported "
+                            "and will cause dask-ms to behave unexpectedly.",
+                            column)
+
         if len(kwargs) > 0:
             raise ValueError("Unhandled kwargs: %s" % kwargs)
 

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -295,7 +295,6 @@ class DatasetFactory(object):
         self.column_keywords = kwargs.pop('column_keywords', False)
         self.table_proxy = kwargs.pop('table_proxy', False)
 
-
         if len(kwargs) > 0:
             raise ValueError("Unhandled kwargs: %s" % kwargs)
 

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -297,10 +297,11 @@ class DatasetFactory(object):
 
         for column in self.group_cols:
             if column in self.taql_where:
-                log.warning("Column %s is present in both group_cols "
-                            "and taql_where. This is unsupported "
-                            "and will cause dask-ms to behave unexpectedly.",
-                            column)
+                raise ValueError("Column %s is present in both group_cols "
+                                 "and taql_where. This is unsupported "
+                                 "because dask-ms uses TAQL to group "
+                                 "datasets internally which conflicts "
+                                 "with user supplied TAQL" % column)
 
         if len(kwargs) > 0:
             raise ValueError("Unhandled kwargs: %s" % kwargs)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -295,12 +295,6 @@ class DatasetFactory(object):
         self.column_keywords = kwargs.pop('column_keywords', False)
         self.table_proxy = kwargs.pop('table_proxy', False)
 
-        for column in self.group_cols:
-            if column in self.taql_where:
-                log.warning("Column %s is present in both group_cols "
-                            "and taql_where. This is unsupported "
-                            "and will cause dask-ms to behave unexpectedly.",
-                            column)
 
         if len(kwargs) > 0:
             raise ValueError("Unhandled kwargs: %s" % kwargs)

--- a/daskms/tests/test_github.py
+++ b/daskms/tests/test_github.py
@@ -1,0 +1,29 @@
+import os
+
+import dask
+import dask.array as da
+from daskms import xds_from_ms
+
+import pytest
+
+
+def test_github_98():
+    ms = "/home/sperkins/data/AF0236_spw01.ms/"
+
+    if not os.path.exists(ms):
+        pytest.skip("AF0236_spw01.ms on which this "
+                    "test depends is not present")
+
+    datasets = xds_from_ms(ms, columns=['DATA', 'ANTENNA1', 'ANTENNA2'],
+                           group_cols=['DATA_DESC_ID'],
+                           taql_where='ANTENNA1 == 5 || ANTENNA2 == 5')
+
+    assert len(datasets) == 2
+    assert datasets[0].DATA_DESC_ID == 0
+    assert datasets[1].DATA_DESC_ID == 1
+
+    for ds in datasets:
+        expr = da.logical_or(ds.ANTENNA1.data == 5, ds.ANTENNA2.data == 5)
+        expr, equal = dask.compute(expr, da.all(expr))
+        assert equal.item() is True
+        assert len(expr) > 0

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -186,7 +186,7 @@ def test_taql_where(ms, index_cols):
 
     assert len(xds) == 2
 
-    # Check group id's
+    # Check group id's, no DATA_DESC_ID == 1 because 
     assert xds[0].DATA_DESC_ID == 0 and xds[0].FIELD_ID == 0
     assert xds[1].DATA_DESC_ID == 0 and xds[1].FIELD_ID == 1
 
@@ -199,32 +199,6 @@ def test_taql_where(ms, index_cols):
 
     fields = da.concatenate([ds.FIELD_ID.data for ds in xds])
     assert_array_equal(fields, [0, 0, 0, 1, 1, 1, 1])
-
-
-def test_group_cols_and_taql_where(ms, caplog):
-    xds_from_ms(ms, group_cols=["FIELD_ID", "DATA_DESC_ID"],
-                taql_where="FIELD_ID > 0")
-
-    assert ("Column FIELD_ID is present in "
-            "both group_cols and taql_where") in caplog.text
-
-
-@pytest.mark.parametrize("group_cols, taql", [
-    [['DATA_DESC_ID'],
-     'ANTENNA1 == 1 || ANTENNA2 == 2'],
-    [['DATA_DESC_ID', 'ANTENNA1', 'ANTENNA2'],
-     'ANTENNA1 == 1 || ANTENNA2 == 2'],
-    [['DATA_DESC_ID', 'FIELD_ID'],
-     'FIELD_ID == 1'],
-    [['DATA_DESC_ID', 'ANTENNA1', 'ANTENNA2'],
-     'FIELD_ID == 1']
-], ids=lambda g: "%s" % g)
-def test_github_98(ms, group_cols, taql):
-    datasets = xds_from_ms(ms, columns=None,
-                           group_cols=group_cols, taql_where=taql)
-
-    for ds in datasets:
-        print(ds.compute())
 
 
 def _proc_map_fn(args):

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -190,13 +190,12 @@ def test_taql_where(ms, index_cols):
     assert_array_equal(fields, [0, 0, 0, 1, 1, 1, 1])
 
 
-def test_group_cols_and_taql_where(ms):
-    with pytest.raises(ValueError) as e:
-        xds_from_ms(ms, group_cols=["FIELD_ID", "DATA_DESC_ID"],
-                    taql_where="FIELD_ID > 0")
+def test_group_cols_and_taql_where(ms, caplog):
+    xds_from_ms(ms, group_cols=["FIELD_ID", "DATA_DESC_ID"],
+                taql_where="FIELD_ID > 0")
 
     assert ("Column FIELD_ID is present in "
-            "both group_cols and taql_where") in str(e.value)
+            "both group_cols and taql_where") in caplog.text
 
 
 def _proc_map_fn(args):

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -179,6 +179,17 @@ def test_taql_where(ms, index_cols):
     fields = da.concatenate([ds.FIELD_ID.data for ds in xds])
     assert_array_equal(fields, [0, 0, 1, 1, 0, 1, 1])
 
+    # Group columns case
+    xds = xds_from_table(ms, taql_where="FIELD_ID >= 0 AND FIELD_ID < 2",
+                         group_cols=["DATA_DESC_ID", "FIELD_ID"],
+                         columns=["FIELD_ID"])
+
+    assert len(xds) == 2
+
+    # Check group id's
+    assert xds[0].DATA_DESC_ID == 0 and xds[0].FIELD_ID == 0
+    assert xds[1].DATA_DESC_ID == 0 and xds[1].FIELD_ID == 1
+
     # Group on each row
     xds = xds_from_table(ms, taql_where="FIELD_ID >= 0 AND FIELD_ID < 2",
                          group_cols=["__row__"],
@@ -209,11 +220,11 @@ def test_group_cols_and_taql_where(ms, caplog):
      'FIELD_ID == 1']
 ], ids=lambda g: "%s" % g)
 def test_github_98(ms, group_cols, taql):
-    datasets = xds_from_ms(ms, columns=['DATA', 'ANTENNA1', 'ANTENNA2'],
+    datasets = xds_from_ms(ms, columns=None,
                            group_cols=group_cols, taql_where=taql)
 
     for ds in datasets:
-        print(ds.dims['row'])
+        print(ds.compute())
 
 
 def _proc_map_fn(args):

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -198,6 +198,24 @@ def test_group_cols_and_taql_where(ms, caplog):
             "both group_cols and taql_where") in caplog.text
 
 
+@pytest.mark.parametrize("group_cols, taql", [
+    [['DATA_DESC_ID'],
+     'ANTENNA1 == 1 || ANTENNA2 == 2'],
+    [['DATA_DESC_ID', 'ANTENNA1', 'ANTENNA2'],
+     'ANTENNA1 == 1 || ANTENNA2 == 2'],
+    [['DATA_DESC_ID', 'FIELD_ID'],
+     'FIELD_ID == 1'],
+    [['DATA_DESC_ID', 'ANTENNA1', 'ANTENNA2'],
+     'FIELD_ID == 1']
+], ids=lambda g: "%s" % g)
+def test_github_98(ms, group_cols, taql):
+    datasets = xds_from_ms(ms, columns=['DATA', 'ANTENNA1', 'ANTENNA2'],
+                           group_cols=group_cols, taql_where=taql)
+
+    for ds in datasets:
+        print(ds.dims['row'])
+
+
 def _proc_map_fn(args):
     import dask.threaded as dt
 

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -198,8 +198,6 @@ def test_group_cols_and_taql_where(ms, caplog):
             "both group_cols and taql_where") in caplog.text
 
 
-
-
 def _proc_map_fn(args):
     import dask.threaded as dt
 

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -190,12 +190,13 @@ def test_taql_where(ms, index_cols):
     assert_array_equal(fields, [0, 0, 0, 1, 1, 1, 1])
 
 
-def test_group_cols_and_taql_where(ms, caplog):
-    xds_from_ms(ms, group_cols=["FIELD_ID", "DATA_DESC_ID"],
-                taql_where="FIELD_ID > 0")
+def test_group_cols_and_taql_where(ms):
+    with pytest.raises(ValueError) as e:
+        xds_from_ms(ms, group_cols=["FIELD_ID", "DATA_DESC_ID"],
+                    taql_where="FIELD_ID > 0")
 
     assert ("Column FIELD_ID is present in "
-            "both group_cols and taql_where") in caplog.text
+            "both group_cols and taql_where") in str(e.value)
 
 
 def _proc_map_fn(args):

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -186,7 +186,8 @@ def test_taql_where(ms, index_cols):
 
     assert len(xds) == 2
 
-    # Check group id's, no DATA_DESC_ID == 1 because 
+    # Check group id's, no DATA_DESC_ID == 1 because it only
+    # contains FIELD_ID == 2
     assert xds[0].DATA_DESC_ID == 0 and xds[0].FIELD_ID == 0
     assert xds[1].DATA_DESC_ID == 0 and xds[1].FIELD_ID == 1
 

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -190,6 +190,16 @@ def test_taql_where(ms, index_cols):
     assert_array_equal(fields, [0, 0, 0, 1, 1, 1, 1])
 
 
+def test_group_cols_and_taql_where(ms, caplog):
+    xds_from_ms(ms, group_cols=["FIELD_ID", "DATA_DESC_ID"],
+                taql_where="FIELD_ID > 0")
+
+    assert ("Column FIELD_ID is present in "
+            "both group_cols and taql_where") in caplog.text
+
+
+
+
 def _proc_map_fn(args):
     import dask.threaded as dt
 

--- a/daskms/tests/test_ordering.py
+++ b/daskms/tests/test_ordering.py
@@ -40,11 +40,11 @@ def test_ordering_query_taql_where_strings(ms, group_cols, index_cols):
                     "    GROWID()[0] as __firstrow__\n"
                     "FROM\n"
                     "    $1\n"
+                    "WHERE\n"
+                    "    ANTENNA1 != ANTENNA2\n"
                     "GROUPBY\n"
                     "    FIELD_ID,\n"
-                    "    SCAN_NUMBER\n"
-                    "HAVING\n"
-                    "    ANTENNA1 != ANTENNA2")
+                    "    SCAN_NUMBER")
 
     taql = group_ordering_taql(table_proxy(ms), group_cols, index_cols)
     assert taql._args[0].replace("\t", " "*4) == (


### PR DESCRIPTION
Fixes #94 
Fixes #100

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
