### PR TITLE
Improve dask task key names

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
+* Improve the dask task key names for clearer graph visualization (:pr:`102`)
 * Cache and inline row runs in write operations (:pr:`96`)
 * Support getcolslice and putcolslice in TableProxy (:pr:`91`)
 * Use weakref.finalize to cleanup TableProxy and Executor objects (:pr:`89`)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -177,7 +177,7 @@ def getter_wrapper(row_orders, *args):
 
 
 def _dataset_variable_factory(table_proxy, table_schema, select_cols,
-                              exemplar_row, orders, chunks, array_prefix):
+                              exemplar_row, orders, chunks, array_suffix):
     """
     Returns a dictionary of dask arrays representing
     a series of getcols on the appropriate table.
@@ -200,7 +200,7 @@ def _dataset_variable_factory(table_proxy, table_schema, select_cols,
         appropriate rows to extract from the table.
     chunks : dict
         Chunking strategy for the dataset.
-    array_prefix : str
+    array_suffix : str
         dask array string prefix
 
     Returns
@@ -248,7 +248,7 @@ def _dataset_variable_factory(table_proxy, table_schema, select_cols,
 
         # Name of the dask array representing this column
         token = dask.base.tokenize(args)
-        name = "-".join((array_prefix, column, token))
+        name = "~".join(("read", column, array_suffix)) + "-" + token
 
         # Construct the array
         dask_array = da.blockwise(getter_wrapper, full_dims,
@@ -352,7 +352,7 @@ class DatasetFactory(object):
 
             # Prefix d
             gid_str = ",".join(str(gid) for gid in group_id)
-            array_prefix = "%s-[%s]" % (short_table_name, gid_str)
+            array_suffix = "[%s]-%s" % (gid_str, short_table_name)
 
             # Create dataset variables
             group_var_dims = _dataset_variable_factory(table_proxy,
@@ -360,7 +360,7 @@ class DatasetFactory(object):
                                                        select_cols,
                                                        exemplar_row,
                                                        order, group_chunks,
-                                                       array_prefix)
+                                                       array_suffix)
 
             # Extract ROWID
             try:

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -512,7 +512,7 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
 
             # Name of the dask array representing this column
             token = dask.base.tokenize(di, args)
-            name = "-".join((table_name, 'write', column, token))
+            name = "".join(("write~", column, "-", table_name, "-", token))
 
             write_col = da.blockwise(putter_wrapper, full_dims,
                                      *args,


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
