### PR TITLE
Work around casacore getcolslice caching

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.4 (YYYY-MM-DD)
 ------------------
+* Work around casacore getcolslice caching (:pr:`107`)
 * Update LICENSE year (:pr:`105`)
 * Update license and production status in pypi classifiers (:pr:`104`)
 * Use WHERE rather than HAVING clause in group ordering TAQL (:pr:`98`)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -234,6 +234,11 @@ def _dataset_variable_factory(table_proxy, table_schema, select_cols,
                 args.append(dim_extents_array(d, c))
                 args.append((d,))
 
+            # Disable getcolslice caching
+            # https://github.com/ska-sa/dask-ms/issues/92
+            # https://github.com/casacore/casacore/issues/1018
+            table_proxy.setmaxcachesize(column, 1).result()
+
             new_axes = {}
         else:
             # We need to inform blockwise about the size of our

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -38,6 +38,7 @@ _proxied_methods = [
     # Modification
     ("addrows", WRITELOCK),
     ("addcols", WRITELOCK),
+    ("setmaxcachesize", WRITELOCK),
     # Reads
     ("getcol", READLOCK),
     ("getcolslice", READLOCK),

--- a/daskms/tests/test_optimisation.py
+++ b/daskms/tests/test_optimisation.py
@@ -7,6 +7,7 @@ import dask.array as da
 from dask.core import flatten
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+import pytest
 
 from daskms import xds_from_ms
 from daskms.optimisation import (inlined_array,
@@ -96,3 +97,18 @@ def test_cached_array(ms):
 
     assert len(_key_cache) == 0
     assert len(_array_cache_cache) == 0
+
+
+@pytest.mark.parametrize("token", ["0xdeadbeaf", None])
+def test_cached_data_token(token):
+    zeros = da.zeros(1000, chunks=100)
+    carray = cached_array(zeros, token)
+
+    dsk = dict(carray.__dask_graph__())
+    k, v = dsk.popitem()
+    cache = v[1]
+
+    if token is None:
+        assert cache.token is not None
+    else:
+        assert cache.token == token


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
