### PR TITLE
Test dask-ms on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   include:
   - env: TARGET=python36
   - env: TARGET=python37
+  - env: TARGET=python38
 sudo: required
 services:
 - docker

--- a/.travis/python38.docker
+++ b/.travis/python38.docker
@@ -1,0 +1,20 @@
+FROM kernsuite/base:5
+
+# Install base requirements
+RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
+RUN DEBIAN_FRONTEND=noninteractive apt update -y
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-casacore python3-distutils  python3.8 python3.8-dev
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3.8 get-pip.py
+ADD . /code
+WORKDIR /code
+
+# Test without xarray
+RUN python3.8 -m pip install .[testing]
+RUN python3.8 -m pip freeze
+RUN python3.8 -m pytest --flake8 -s -vvv /code/daskms
+
+# Test with xarray
+RUN python3.8 -m pip install .[testing,xarray]
+RUN python3.8 -m pip freeze
+RUN python3.8 -m pytest --flake8 -s -vvv /code/daskms

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.2.5 (YYYY-MM-DD)
+------------------
+* Test dask-ms on Python 3.8 (:pr:`112`)
+
 0.2.4 (2020-04-24)
 ------------------
 * Documentation updates (:pr:`110`)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
