### PR TITLE
Remove Python 3.6 deadlock in weakref.finalize call

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.2.5 (YYYY-MM-DD)
+------------------
+* Remove TableProxy weakref.finalize (:pr:`113`)
+
 0.2.4 (2020-04-24)
 ------------------
 * Documentation updates (:pr:`110`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.5 (YYYY-MM-DD)
 ------------------
-* Remove potential deadlock in TableProxy weakref.finalize (:pr:`113`)
+* Remove deadlock in TableProxy weakref.finalize on Python 3.6 (:pr:`113`)
 * Use python-casacore wheels for travis testing, instead of kernsuite packages (:pr:`115`)
 
 0.2.4 (2020-04-24)

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -257,6 +257,35 @@ def _table_future_close(table_future):
 # that the Executor's finalizer, and by further implication,
 # the ThreadPoolExecutor.shutdown has not yet been called.
 def _table_future_finaliser(ex, table_future, args, kwargs):
+    """
+    Closes the table object in the thread it was created
+    on Python >= 3.7 and in the garbage collection thread
+    in Python 3.6.
+
+    Parameters
+    ----------
+    ex : :class:`daskms.table_executor.Executor`
+        Executor on which table operations should be performed
+    table_future : :class:`concurrent.futures.Future`
+        Future referring to the CASA table object. Should've
+        been created in ``ex``.
+    args : tuple
+        Arguments used to create the table future by
+        :class:`daskms.table_proxy.TableProxy`.
+    kwargs : kwargs
+        Keyword arguments used to create the table future by
+        :class:`daskms.table_proxy.TableProxy`.
+
+    Notes
+    -----
+    ``args`` and ``kwargs`` aren't used by the function but should
+    be passed through so that any dependencies are garbage collected
+    before the TableProxy is. Primarily this is to ensure that
+    taql_proxy's are garbage collected before their dependant
+    tables.
+
+    """
+
     if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
         # ThreadPoolExecutor on Python 3.7 uses a SimpleQueue
         # which is re-entrant safe, so we can submit our table

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -315,7 +315,7 @@ class TableProxy(object, metaclass=TableProxyMetaClass):
         Parameters
         ----------
         factory : callable
-            Function to call which creates the CASA table
+            Function which creates the CASA table
         *args : tuple
             Positional arguments passed to factory.
         **kwargs : dict


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
