### PR TITLE
Depend on python-casacore wheels for travis testing

### DIFF
--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -3,7 +3,7 @@ FROM kernsuite/base:5
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-casacore python3-distutils  python3.6 python3.6-dev 
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-distutils  python3.6 python3.6-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.6 get-pip.py
 ADD . /code

--- a/.travis/python37.docker
+++ b/.travis/python37.docker
@@ -3,7 +3,7 @@ FROM kernsuite/base:5
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-casacore python3-distutils  python3.7 python3.7-dev 
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential curl git python3-distutils  python3.7 python3.7-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.7 get-pip.py
 ADD . /code

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.2.5 (YYYY-MM-DD)
+------------------
+* Use python-casacore wheels for travis testing, instead of kernsuite packages (:pr:`115`)
+
 0.2.4 (2020-04-24)
 ------------------
 * Documentation updates (:pr:`110`)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
