### PR TITLE
Support dictionary writes via putvarcol

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.6 (YYYY-MM-DD)
 ------------------
+* Support dictionary writes via putvarcol (:pr:`119`)
 * Update to pytest-flake8 1.0.6 (:pr:`117`)
 * Test on Python 3.8 (:pr:`116`)
 * Depend on python-casacore 3.3.1 (:pr:`116`)

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -8,7 +8,12 @@ import pyrap.tables as pt
 import pytest
 
 from daskms.query import orderby_clause, where_clause
-from dask.optimization import key_split
+
+try:
+    from dask.optimization import key_split
+except ImportError:
+    from dask.utils import key_split
+
 from daskms.utils import (group_cols_str, index_cols_str,
                           select_cols_str, assert_liveness,
                           table_path_split)

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -167,10 +167,11 @@ def putter_wrapper(row_orders, *args):
         # array metadata is plainly incorrect as a dict isn't a valid
         # numpy array representation, so we heuristically guess the
         # output shape here.
-        # Dimension slicing is also not supported
-        # (putvarcol doesn't support it in any case).
+        # Dimension slicing is also not supported as
+        # putvarcol doesn't support it in any case.
         if nextent_args > 0:
-            raise ValueError("Extents unsupported for dictionary writes")
+            raise ValueError("Chunked writes for secondary dimensions "
+                             "unsupported for dictionary data")
 
         out_shape = (1,) * max(len(v.shape) for v in data.values())
         dict_data = True


### PR DESCRIPTION
Functionality exists but won't be exposed to all but the most advanced
user.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
