### PR TITLE
Remove table close in ThreadPool

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.6 (YYYY-MM-DD)
 ------------------
+* Remove table close in ThreadPool for the last time (:pr:`122`)
 * Support dictionary writes via putvarcol (:pr:`119`)
 * Use getcell instead of getcellslice in sorted orderings (:pr:`120`)
 * Update to pytest-flake8 1.0.6 (:pr:`117`)

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
 from itertools import zip_longest
 import logging
 from threading import Lock
@@ -285,23 +284,7 @@ def _table_future_finaliser(ex, table_future, args, kwargs):
     tables.
 
     """
-
-    if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
-        # ThreadPoolExecutor on Python 3.7 uses a SimpleQueue
-        # which is re-entrant safe, so we can submit our table
-        # close operation on the Thread Pool
-        ex.impl.submit(_table_future_close, table_future)
-    else:
-        # ThreadPoolExecutor on Python 3.6 uses Queue,
-        # which is not re-entrant safe,
-        # https://codewithoutrules.com/2017/08/16/concurrency-python/
-        # so we submit our table close operations in the
-        # garbage collection thread, which
-        # may not be the same thread in which the table was
-        # created. This should be OK with the flush operations
-        # we place after all our write operations in the
-        # Executor thread
-        _table_future_close(table_future)
+    _table_future_close(table_future)
 
 
 class TableProxy(object, metaclass=TableProxyMetaClass):


### PR DESCRIPTION
This pattern can still deadlock on Python > 3.7 if Garbage Collection
has not taken place.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
