### PR TITLE
Allow inlining of different layers, not just the top

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Allow Multi-Layer Inlining (:pr:`125`)
 * Support DATA Column Expressions (:pr:`124`)
 
 

--- a/daskms/optimisation.py
+++ b/daskms/optimisation.py
@@ -164,29 +164,34 @@ def inlined_array(a, inline_arrays=None):
         raise TypeError("Invalid inline_arrays, must be "
                         "(None, list, tuple, dask.array.Array)")
 
+    inline_names = set(a.name for a in inline_arrays)
     layers = agraph.layers.copy()
     deps = {k: v.copy() for k, v in agraph.dependencies.items()}
-    inline_keys = set()
-    dsk = dict(layers[a.name])
+    # We want to inline layers that depend on the inlined arrays
+    inline_layers = set(k for k, v in deps.items()
+                        if len(inline_names.intersection(v)) > 0)
 
-    # Inline specified arrays
-    for array in inline_arrays:
-        # Remove array from layers and dependencies
-        try:
-            dsk.update(layers.pop(array.name))
-            del deps[array.name]
-            deps[a.name].discard(array.name)
-        except KeyError:
-            raise ValueError(f"{array.name} is not a "
-                             f"valid dependency of {a.name}")
+    for layer_name in inline_layers:
+        dsk = dict(layers[layer_name])
+        layer_keys = set(dsk.keys())
+        inline_keys = set()
 
-        # Record keys to inline
-        inline_keys.update(flatten(array.__dask_keys__()))
+        for array in inline_arrays:
+            dsk.update(layers[array.name])
+            deps.pop(array.name, None)
+            deps[layer_name].discard(array.name)
+#            inline_keys.update(flatten(array.__dask_keys__()))
+            inline_keys.update(layers[array.name].keys())
 
-    dsk2 = inline(dsk, keys=inline_keys, inline_constants=True)
-    dsk3, _ = cull(dsk2, akeys)
+        dsk2 = inline(dsk, keys=inline_keys, inline_constants=True)
+        layers[layer_name], _ = cull(dsk2, layer_keys)
 
-    layers[a.name] = dsk3
+    # Remove layers containing the inlined arrays
+    for inline_name in inline_names:
+        layers.pop(inline_name)
+
+    # Record keys to inline
+
     graph = HighLevelGraph(layers, deps)
 
     return da.Array(graph, a.name, a.chunks, a.dtype)

--- a/daskms/optimisation.py
+++ b/daskms/optimisation.py
@@ -180,7 +180,6 @@ def inlined_array(a, inline_arrays=None):
             dsk.update(layers[array.name])
             deps.pop(array.name, None)
             deps[layer_name].discard(array.name)
-#            inline_keys.update(flatten(array.__dask_keys__()))
             inline_keys.update(layers[array.name].keys())
 
         dsk2 = inline(dsk, keys=inline_keys, inline_constants=True)
@@ -190,8 +189,4 @@ def inlined_array(a, inline_arrays=None):
     for inline_name in inline_names:
         layers.pop(inline_name)
 
-    # Record keys to inline
-
-    graph = HighLevelGraph(layers, deps)
-
-    return da.Array(graph, a.name, a.chunks, a.dtype)
+    return da.Array(HighLevelGraph(layers, deps), a.name, a.chunks, a.dtype)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
