### PR TITLE
Fixes array inlining for write operations.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Fix array inlining for writes (:pr:`126`) 
 * Allow Multi-Layer Inlining (:pr:`125`)
 * Support DATA Column Expressions (:pr:`124`)
 

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -619,10 +619,15 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
             # We only need to pass in dimension extent arrays if
             # there is more than one chunk in any of the non-row columns.
             # In that case, we can putcol, otherwise putcolslice is required
+
+            inlinable_arrays = [row_order]
+
             if not all(len(c) == 1 for c in array.chunks[1:]):
                 # Add extent arrays
                 for d, c in zip(full_dims[1:], array.chunks[1:]):
-                    args.append(dim_extents_array(d, c))
+                    extent_array = dim_extents_array(d, c)
+                    args.append(extent_array)
+                    inlinable_arrays.append(extent_array)
                     args.append((d,))
 
             # Add other variables
@@ -644,7 +649,7 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
                                      dtype=np.bool)
 
             if inline:
-                write_col = inlined_array(write_col, [row_order])
+                write_col = inlined_array(write_col, inlinable_arrays)
 
             write_vars[column] = (full_dims, write_col)
 


### PR DESCRIPTION
- [X] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [X] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

This minor change should fix poor ordering behaviour arising from incomplete inlining in write operations.

## Ordering before change:
![Screenshot from 2020-12-14 15-29-47](https://user-images.githubusercontent.com/6582745/102086724-36d98500-3e21-11eb-9253-a3b89fff1822.png)

## Ordering after change:
![Screenshot from 2020-12-14 15-30-33](https://user-images.githubusercontent.com/6582745/102086808-57094400-3e21-11eb-929e-d645247b1208.png)
