### PR TITLE
Fix typo in __daskms_partition_schema__

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,8 +4,8 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
-* Experimental arrow support (:pr:`130`, :pr:`132`)
-* Experimental zarr support (:pr:`129`)
+* Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`)
+* Experimental zarr support (:pr:`129`, :pr:`133`)
 * Test data fix (:pr:`128`)
 * Fix array inlining for writes (:pr:`126`)
 * Allow Multi-Layer Inlining (:pr:`125`)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -21,7 +21,7 @@ from daskms.table_schemas import lookup_table_schema
 from daskms.utils import table_path_split
 
 _DEFAULT_ROW_CHUNKS = 10000
-PARTITION_KEY = "__daskms_partitition_schema__"
+PARTITION_KEY = "__daskms_partition_schema__"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
