### PR TITLE
Encode python types in attrs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
-* Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`)
+* Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`)
 * Experimental zarr support (:pr:`129`, :pr:`133`)
 * Test data fix (:pr:`128`)
 * Fix array inlining for writes (:pr:`126`)

--- a/daskms/experimental/arrow/tests/test_parquet.py
+++ b/daskms/experimental/arrow/tests/test_parquet.py
@@ -75,9 +75,13 @@ def test_xds_to_parquet(ms, tmp_path_factory):
 
     for ds, batch in zip(datasets, record_batches):
         for column, array in zip(batch.schema.names, batch.columns):
-            var = getattr(ds, column).data
-            assert isinstance(array, TensorArray if var.ndim > 1 else pa.Array)
-            assert_array_equal(var, array.to_numpy())
+            if column in ds.attrs:
+                assert_array_equal(getattr(ds, column), array.to_numpy())
+            else:
+                var = getattr(ds, column).data
+                expected_patype = TensorArray if var.ndim > 1 else pa.Array
+                assert isinstance(array, expected_patype)
+                assert_array_equal(var, array.to_numpy())
 
     pq_datasets = xds_from_parquet(store, chunks={"row": 1})
     assert len(datasets) == len(pq_datasets)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -380,9 +380,12 @@ class DatasetFactory(object):
 
             # Assign values for the dataset's grouping columns
             # as attributes
-            attrs = dict(zip(self.group_cols, group_id))
-            attrs[PARTITION_KEY] = tuple((c, g.dtype.name) for c, g
-                                         in zip(self.group_cols, group_id))
+            attrs = {PARTITION_KEY: tuple((c, g.dtype.name) for c, g
+                                          in zip(self.group_cols, group_id))}
+
+            # Use python types which are json serializable
+            group_id = [gid.item() for gid in group_id]
+            attrs.update(zip(self.group_cols, group_id))
 
             datasets.append(Dataset(group_var_dims, attrs=attrs,
                                     coords=coords))


### PR DESCRIPTION
numpy types aren't JSON encodable

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
