### PR TITLE
Guard arrow usage on import fail

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
-* Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`, :pr:`136`)
+* Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`, :pr:`136`, :pr:`138`)
 * Experimental zarr support (:pr:`129`, :pr:`133`)
 * Test data fix (:pr:`128`)
 * Fix array inlining for writes (:pr:`126`)

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -21,8 +21,23 @@ try:
     import pyarrow as pa
 except ImportError as e:
     pyarrow_import_error = e
+    _UNHANDLED_TYPES = ()
 else:
     pyarrow_import_error = None
+
+    _UNHANDLED_TYPES = (
+        pa.DictionaryType,
+        pa.ListType,
+        pa.MapType,
+        pa.StructType,
+        pa.UnionType,
+        pa.TimestampType,
+        pa.Time32Type,
+        pa.Time64Type,
+        pa.FixedSizeBinaryType,
+        pa.Decimal128Type,
+    )
+
 
 try:
     import pyarrow.parquet as pq
@@ -31,18 +46,6 @@ except ImportError as e:
 else:
     pyarrow_import_error = None
 
-_UNHANDLED_TYPES = (
-    pa.DictionaryType,
-    pa.ListType,
-    pa.MapType,
-    pa.StructType,
-    pa.UnionType,
-    pa.TimestampType,
-    pa.Time32Type,
-    pa.Time64Type,
-    pa.FixedSizeBinaryType,
-    pa.Decimal128Type,
-)
 
 _parquet_table_lock = Lock()
 _parquet_table_cache = weakref.WeakValueDictionary()


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
