### PR TITLE
zarr string object handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
-* Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`, :pr:`136`)
+* Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`, :pr:`136`, :pr:`138`)
 * Experimental zarr support (:pr:`129`, :pr:`133`)
 * Test data fix (:pr:`128`)
 * Fix array inlining for writes (:pr:`126`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.2.7 (YYYY-MM-DD)
 ------------------
 * Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`, :pr:`136`, :pr:`138`)
-* Experimental zarr support (:pr:`129`, :pr:`133`)
+* Experimental zarr support (:pr:`129`, :pr:`133`, :pr:`139`)
 * Test data fix (:pr:`128`)
 * Fix array inlining for writes (:pr:`126`)
 * Allow Multi-Layer Inlining (:pr:`125`)

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -21,8 +21,23 @@ try:
     import pyarrow as pa
 except ImportError as e:
     pyarrow_import_error = e
+    _UNHANDLED_TYPES = ()
 else:
     pyarrow_import_error = None
+
+    _UNHANDLED_TYPES = (
+        pa.DictionaryType,
+        pa.ListType,
+        pa.MapType,
+        pa.StructType,
+        pa.UnionType,
+        pa.TimestampType,
+        pa.Time32Type,
+        pa.Time64Type,
+        pa.FixedSizeBinaryType,
+        pa.Decimal128Type,
+    )
+
 
 try:
     import pyarrow.parquet as pq
@@ -31,18 +46,6 @@ except ImportError as e:
 else:
     pyarrow_import_error = None
 
-_UNHANDLED_TYPES = (
-    pa.DictionaryType,
-    pa.ListType,
-    pa.MapType,
-    pa.StructType,
-    pa.UnionType,
-    pa.TimestampType,
-    pa.Time32Type,
-    pa.Time64Type,
-    pa.FixedSizeBinaryType,
-    pa.Decimal128Type,
-)
 
 _parquet_table_lock = Lock()
 _parquet_table_cache = weakref.WeakValueDictionary()

--- a/daskms/experimental/arrow/tests/test_parquet.py
+++ b/daskms/experimental/arrow/tests/test_parquet.py
@@ -32,7 +32,6 @@ def test_parquet_roundtrip(tmp_path_factory):
     shape = (nrow, nchan, ncorr)
     data = np.random.random(shape) + np.random.random(shape)*1j
     uvw = np.random.random((nrow, 3))
-    names = np.array(["row-%d" % r for r in range(nrow)], dtype=np.object)
 
     columns = {
         "TIME": time,
@@ -40,7 +39,6 @@ def test_parquet_roundtrip(tmp_path_factory):
         "ANTENNA2": ant2,
         "UVW": uvw,
         "DATA": data,
-        "NAMES": names,
     }
 
     arrow_columns = {k: TensorArray.from_numpy(v) for k, v in columns.items()}

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -4,6 +4,7 @@ from weakref import WeakValueDictionary
 
 import dask.array as da
 import numpy as np
+import numcodecs
 
 from daskms.utils import arg_hasher, requires
 from daskms.experimental.utils import (encode_attr,
@@ -86,9 +87,12 @@ class ZarrDatasetFactory(metaclass=ZarrDatasetFactoryMetaClass):
                 ds_group.attrs.update(encode_attr(self.attrs))
 
                 for name, (dims, shape, chunks, dtype) in self.schema.items():
+                    codec = numcodecs.Pickle() if dtype == np.object else None
+
                     array = ds_group.require_dataset(name, shape,
                                                      chunks=chunks,
                                                      dtype=dtype,
+                                                     object_codec=codec,
                                                      exact=True)
                     array.attrs[DASKMS_ATTR_KEY] = {"dims": dims}
 

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -1,8 +1,31 @@
 import dask
+import dask.array as da
+import numpy as np
 from numpy.testing import assert_array_equal
 
 from daskms import xds_from_ms
+from daskms.dataset import Dataset
 from daskms.experimental.zarr import xds_from_zarr, xds_to_zarr
+
+
+def test_string_array(tmp_path_factory):
+    zarr_store = tmp_path_factory.mktemp("string-arrays") / "test.zarr"
+
+    data = ["hello", "this", "strange new world",
+            "full of", "interesting", "stuff"]
+    data = np.array(data, dtype=np.object).reshape(3, 2)
+    data = da.from_array(data, chunks=((1, 2), (1, 1)))
+
+    datasets = [Dataset({"DATA": (("x", "y"), data)})]
+    writes = xds_to_zarr(datasets, zarr_store)
+    dask.compute(writes)
+
+    new_datasets = xds_from_zarr(zarr_store)
+
+    assert len(new_datasets) == len(datasets)
+
+    for nds, ds in zip(new_datasets, datasets):
+        assert_array_equal(nds.DATA.data, ds.DATA.data)
 
 
 def test_xds_to_zarr(ms, tmp_path_factory):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
