### PR TITLE
Correct dataset persistence issues

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Correct dataset persistence issues (:pr:`140`)
 * Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`, :pr:`136`, :pr:`138`)
 * Experimental zarr support (:pr:`129`, :pr:`133`)
 * Test data fix (:pr:`128`)

--- a/daskms/dataset.py
+++ b/daskms/dataset.py
@@ -127,7 +127,9 @@ class Variable(object):
 
     def __dask_postcompute__(self):
         fn, args = self.data.__dask_postcompute__()
-        args = (fn, args, self.data.name, self.dims, self.attrs)
+
+        name = (self.data.name if isinstance(self.data, da.Array) else None)
+        args = (fn, args, name, self.dims, self.attrs)
         return (self.finalize_compute, args)
 
     @staticmethod

--- a/daskms/dataset.py
+++ b/daskms/dataset.py
@@ -122,21 +122,23 @@ class Variable(object):
         return self.data.__dask_scheduler__
 
     @staticmethod
-    def finalize_compute(results, fn, args, dims, attrs):
+    def finalize_compute(results, fn, args, name, dims, attrs):
         return Variable(dims, fn(results, *args), attrs=attrs)
 
     def __dask_postcompute__(self):
         fn, args = self.data.__dask_postcompute__()
-        return (self.finalize_compute, (fn, args, self.dims, self.attrs))
+        args = (fn, args, self.data.name, self.dims, self.attrs)
+        return (self.finalize_compute, args)
 
     @staticmethod
-    def finalize_persist(results, fn, args, dims, attrs):
-        results = {k: v for k, v in results.items() if k[0] == args[0]}
+    def finalize_persist(results, fn, args, name, dims, attrs):
+        results = {k: v for k, v in results.items() if k[0] == name}
         return Variable(dims, fn(results, *args), attrs=attrs)
 
     def __dask_postpersist__(self):
         fn, args = self.data.__dask_postpersist__()
-        return (self.finalize_persist, (fn, args, self.dims, self.attrs))
+        args = (fn, args, self.data.name, self.dims, self.attrs)
+        return (self.finalize_persist, args)
 
 
 class DimensionInferenceError(ValueError):

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -8,7 +8,7 @@ from daskms.experimental.zarr import xds_from_zarr, xds_to_zarr
 def test_xds_to_zarr(ms, tmp_path_factory):
     zarr_store = tmp_path_factory.mktemp("zarr_store") / "test.zarr"
 
-    ms_datasets = dask.persist(xds_from_ms(ms))[0]
+    ms_datasets = xds_from_ms(ms)
     writes = xds_to_zarr(ms_datasets, zarr_store)
     dask.compute(writes)
 

--- a/daskms/tests/test_dataset.py
+++ b/daskms/tests/test_dataset.py
@@ -506,13 +506,17 @@ def test_dataset_dask(ms):
 
         # Now have numpy array in the graph
         assert len(v3.data.__dask_keys__()) == 1
-        assert isinstance(v3.data.__dask_graph__().values()[0], np.ndarray)
+        data = next(iter(v3.__dask_graph__().values()))
+        assert isinstance(data, np.ndarray)
+        assert_array_equal(v2.data, v3.data)
 
     # Test compute
     nds = dask.compute(ds)[0]
 
     for k, v in nds.data_vars.items():
         assert isinstance(v.data, np.ndarray)
+        cdata = getattr(ds, k).data
+        assert_array_equal(cdata, v.data)
 
     # Test persist
     nds = dask.persist(ds)[0]
@@ -522,4 +526,8 @@ def test_dataset_dask(ms):
 
         # Now have numpy array iin the graph
         assert len(v.data.__dask_keys__()) == 1
-        assert isinstance(v.data.__dask_graph__().values()[0], np.ndarray)
+        data = next(iter(v.data.__dask_graph__().values()))
+        assert isinstance(data, np.ndarray)
+
+        cdata = getattr(ds, k).data
+        assert_array_equal(cdata, v.data)

--- a/daskms/tests/test_dataset.py
+++ b/daskms/tests/test_dataset.py
@@ -13,6 +13,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pyrap.tables as pt
 import pytest
 
+from daskms import xds_from_ms
 from daskms.dataset import Dataset, Variable
 from daskms.reads import read_datasets
 from daskms.writes import write_datasets
@@ -484,6 +485,12 @@ def test_dataset_computes_and_values(ms):
         assert isinstance(v.data, np.ndarray)
         assert_array_equal(v.data, ds.data_vars[k].data)
         assert_array_equal(v.values, ds.data_vars[k].data)
+
+
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/4882")
+def test_dataset_xarray(ms):
+    datasets = xds_from_ms(ms)
+    datasets = dask.persist(datasets)
 
 
 def test_dataset_dask(ms):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
