### PR TITLE
Avoid explicit CASA read locking by opening tables in 'usernoread' mode

### DIFF
--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -306,7 +306,7 @@ class DatasetFactory(object):
 
     def _table_proxy_factory(self):
         return TableProxy(pt.table, self.table_path, ack=False,
-                          readonly=True, lockoptions='user',
+                          readonly=True, lockoptions="usernoread",
                           __executor_key__=executor_key(self.canonical_name))
 
     def _table_schema(self):

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -230,7 +230,7 @@ def descriptor_builder(table, descriptor):
 
 def _writable_table_proxy(table_name):
     return TableProxy(pt.table, table_name, ack=False,
-                      readonly=False, lockoptions='user',
+                      readonly=False, lockoptions="usernoread",
                       __executor_key__=executor_key(table_name))
 
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
