### PR TITLE
Convert code-base to f-strings with flynt

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Convert code-base to f-strings with flynt (:pr:`144`)
 * Consolidate Dataset Types into daskms.dataset (:pr:`143`)
 * Correct Dataset persistence issues (:pr:`140`)
 * Experimental arrow support (:pr:`130`, :pr:`132`, :pr:`133`, :pr:`135`, :pr:`136`, :pr:`138`)

--- a/daskms/columns.py
+++ b/daskms/columns.py
@@ -184,8 +184,8 @@ def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
             shape = (len(exemplar),)
             assert dtype == object
         else:
-            raise ColumnMetadataError("Unhandled exemplar "
-                                      "type '%s'" % type(exemplar))
+            raise ColumnMetadataError(f"Unhandled exemplar type "
+                                      f"'{type(exemplar)}'")
 
         # NOTE(sjperkins)
         # -1 implies each row can be any shape whatsoever

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -37,7 +37,7 @@ def big_ms(tmp_path_factory, request):
     corr = 4
     ant = 7
 
-    create_table_query = """
+    create_table_query = f"""
     CREATE TABLE {fn}
     [FIELD_ID I4,
     TIME R8,
@@ -48,7 +48,7 @@ def big_ms(tmp_path_factory, request):
     STATE_ID I4,
     DATA C8 [NDIM=2, SHAPE=[{chan}, {corr}]]]
     LIMIT {row}
-    """.format(fn=fn, row=row, chan=chan, corr=corr)
+    """
 
     rs = np.random.RandomState(42)
     data_shape = (row, chan, corr)
@@ -86,8 +86,8 @@ def ms(tmp_path_factory):
     msdir = tmp_path_factory.mktemp("msdir", numbered=True)
     fn = os.path.join(str(msdir), "test.ms")
 
-    create_table_query = """
-    CREATE TABLE %s
+    create_table_query = f"""
+    CREATE TABLE {fn}
     [FIELD_ID I4,
     ANTENNA1 I4,
     ANTENNA2 I4,
@@ -98,7 +98,7 @@ def ms(tmp_path_factory):
     TIME R8,
     DATA C8 [NDIM=2, SHAPE=[16, 4]]]
     LIMIT 10
-    """ % fn
+    """
 
     # Common grouping columns
     field = [0,   0,   0,   1,   1,   1,   1,   2,   2,   2]

--- a/daskms/dataset.py
+++ b/daskms/dataset.py
@@ -378,7 +378,7 @@ else:
             try:
                 return self._attrs[name]
             except KeyError:
-                raise AttributeError("Invalid Attribute %s" % name)
+                raise AttributeError(f"Invalid Attribute {name}")
 
         def copy(self):
             """ Returns a copy of the Dataset """

--- a/daskms/descriptors/builder.py
+++ b/daskms/descriptors/builder.py
@@ -16,7 +16,7 @@ descriptor_builders = {}
 
 def is_valid_variable_name(name):
     try:
-        parse('{} = None'.format(name))
+        parse(f'{name} = None')
         return True
     except (SyntaxError, ValueError, TypeError):
         return False
@@ -25,12 +25,11 @@ def is_valid_variable_name(name):
 def register_descriptor_builder(name):
     def decorator(cls):
         if name in descriptor_builders:
-            raise ValueError("'%s' already registered as a "
-                             "descriptor builder" % name)
+            raise ValueError(f"'{name}' already registered as "
+                             f"a descriptor builder")
 
         if not is_valid_variable_name(name):
-            raise ValueError("'%s' is not a valid "
-                             "Python variable name." % name)
+            raise ValueError(f"'{name}' is not a valid Python variable name.")
 
         descriptor_builders[name] = cls
         return cls
@@ -155,7 +154,7 @@ def variable_column_descriptor(column, variable):
     casa_type = infer_casa_type(dtypes.pop())
 
     desc = {'_c_order': True,
-            'comment': '%s column' % column,
+            'comment': f'{column} column',
             'dataManagerGroup': 'StandardStMan',
             'dataManagerType': 'StandardStMan',
             'keywords': {},

--- a/daskms/descriptors/ms.py
+++ b/daskms/descriptors/ms.py
@@ -36,7 +36,7 @@ class MSDescriptorBuilder(AbstractDescriptorBuilder):
         # Imaging DATA columns
         desc.update({column: {
             '_c_order': True,
-            'comment': 'The Visibility %s Column' % column,
+            'comment': f'The Visibility {column} Column',
             'dataManagerGroup': 'StandardStMan',
             'dataManagerType': 'StandardStMan',
             'keywords': {'UNIT': 'Jy'},
@@ -85,7 +85,7 @@ class MSDescriptorBuilder(AbstractDescriptorBuilder):
         try:
             desc = {k: default_desc[k] for k in self.REQUIRED_FIELDS}
         except KeyError as e:
-            raise RuntimeError("'%s' not in REQUIRED_FIELDS" % str(e))
+            raise RuntimeError(f"'{str(e)}' not in REQUIRED_FIELDS")
 
         # Put indexing columns into an Incremental Storage Manager by default
         for column in self.INDEX_COLS:
@@ -139,7 +139,7 @@ class MSDescriptorBuilder(AbstractDescriptorBuilder):
         col_desc['shape'] = shape
         col_desc['ndim'] = len(shape)
         col_desc['option'] |= 4
-        col_desc['dataManagerGroup'] = "%s_GROUP" % column
+        col_desc['dataManagerGroup'] = f"{column}_GROUP"
         col_desc['dataManagerType'] = "TiledColumnStMan"
 
     def fix_columns(self, variables, desc, dim_sizes):
@@ -195,14 +195,14 @@ class MSDescriptorBuilder(AbstractDescriptorBuilder):
         try:
             shape = desc['shape']
         except KeyError:
-            raise ValueError("No shape in descriptor %s" % desc)
+            raise ValueError(f"No shape in descriptor {desc}")
         else:
             rev_shape = tuple(reversed(shape))
 
         try:
             casa_type = desc['valueType']
         except KeyError:
-            raise ValueError("No valueType in descriptor %s" % desc)
+            raise ValueError(f"No valueType in descriptor {desc}")
         else:
             dtype = infer_dtype(casa_type, desc)
             nbytes = np.dtype(dtype).itemsize

--- a/daskms/descriptors/ms_subtable.py
+++ b/daskms/descriptors/ms_subtable.py
@@ -11,8 +11,8 @@ from daskms.table_schemas import SUBTABLES
 class MSSubTableDescriptorBuilder(AbstractDescriptorBuilder):
     def __init__(self, subtable):
         if subtable not in SUBTABLES:
-            raise ValueError("'%s' is not a valid Measurement Set "
-                             "sub-table" % subtable)
+            raise ValueError(f"'{subtable}' is not a valid "
+                             f"Measurement Set sub-table")
 
         self.subtable = subtable
         self.DEFAULT_TABLE_DESC = pt.required_ms_desc(subtable)
@@ -25,7 +25,7 @@ class MSSubTableDescriptorBuilder(AbstractDescriptorBuilder):
         try:
             desc = {k: default_desc[k] for k in self.REQUIRED_FIELDS}
         except KeyError as e:
-            raise RuntimeError("'%s' is not in REQUIRED_FIELDS" % str(e))
+            raise RuntimeError(f"'{str(e)}' is not in REQUIRED_FIELDS")
 
         # Now copy/create descriptors for supplied variables
         for k, v in variables.items():

--- a/daskms/descriptors/tests/test_builder_factory.py
+++ b/daskms/descriptors/tests/test_builder_factory.py
@@ -20,16 +20,16 @@ _root = Path("C:/" if platform.system() == "Windows" else os.sep,
 
 @pytest.mark.parametrize("filename, builder_cls", [
     (_root / "test.ms", MSDescriptorBuilder),
-    (_root / "test.ms{s}".format(s=os.sep), MSDescriptorBuilder),
+    (_root / f"test.ms{os.sep}", MSDescriptorBuilder),
     (_root / "test.ms{s}{s}".format(s=os.sep), MSDescriptorBuilder),
     # Indirectly accessed subtable correctly identified
     (_root / "test.ms::SOURCE", MSSubTableDescriptorBuilder),
-    (_root / "test.ms::SOURCE{s}".format(s=os.sep),
+    (_root / f"test.ms::SOURCE{os.sep}",
      MSSubTableDescriptorBuilder),
     # Directly accessed subtable not identified
     (_root / "test.ms" / "SOURCE",
      DefaultDescriptorBuilder),
-    (_root / "test.ms" / "SOURCE{s}".format(s=os.sep),
+    (_root / "test.ms" / f"SOURCE{os.sep}",
      DefaultDescriptorBuilder),
     # Default Table
     (_root / "test.table", DefaultDescriptorBuilder),

--- a/daskms/descriptors/tests/test_ms_builder.py
+++ b/daskms/descriptors/tests/test_ms_builder.py
@@ -16,7 +16,7 @@ from daskms.descriptors.ms import MSDescriptorBuilder
      ("MODEL_DATA", ("row", "chan", "corr"), np.complex128)],
     [("IMAGING_WEIGHT", ("row", "chan"), np.float32),
      ("SIGMA_SPECTRUM", ("row", "chan", "corr"), np.float)],
-], ids=lambda v: "variables=%s" % v)
+], ids=lambda v: f"variables={v}")
 @pytest.mark.parametrize("chunks", [
     {"row": (2, 2, 2, 2, 2),
      "chan": (4, 4, 4, 4),

--- a/daskms/descriptors/tests/test_ms_subtable_builder.py
+++ b/daskms/descriptors/tests/test_ms_subtable_builder.py
@@ -25,7 +25,7 @@ def test_ms_subtable_builder(tmp_path, table):
     required_cols = {k for k in pt.required_ms_desc(table).keys()
                      if not k.startswith('_')}
 
-    filename = str(tmp_path / ("%s.table" % table))
+    filename = str(tmp_path / (f"{table}.table"))
 
     with pt.table(filename, tab_desc, dminfo=dminfo, ack=False) as T:
         T.addrows(10)

--- a/daskms/optimisation.py
+++ b/daskms/optimisation.py
@@ -43,7 +43,7 @@ class Key(metaclass=KeyMetaClass):
         return hash(self.key)
 
     def __repr__(self):
-        return "Key%s" % (self.key,)
+        return f"Key{self.key}"
 
     def __reduce__(self):
         return (Key, (self.key,))
@@ -96,7 +96,7 @@ class ArrayCache(metaclass=ArrayCacheMetaClass):
         return (ArrayCache, (self.token,))
 
     def __repr__(self):
-        return "ArrayCache[%s]" % self.token
+        return f"ArrayCache[{self.token}]"
 
 
 def cached_array(array, token=None):

--- a/daskms/ordering.py
+++ b/daskms/ordering.py
@@ -43,7 +43,7 @@ def row_run_factory(rows, sort='auto', sort_dir="read"):
             inv_argsort[argsort] = np.arange(argsort.size, dtype=dtype)
             resort = inv_argsort
         else:
-            raise ValueError("Invalid sort_dir '%s'" % sort_dir)
+            raise ValueError(f"Invalid sort_dir '{sort_dir}'")
 
         # Use sorted rows for creating row runs
         rows = sorted_rows
@@ -68,9 +68,9 @@ def ordering_taql(table_proxy, index_cols, taql_where=''):
     orderby = "\n" + orderby_clause(index_cols)
 
     if taql_where != '':
-        taql_where = "\nWHERE\n\t%s" % taql_where
+        taql_where = f"\nWHERE\n\t{taql_where}"
 
-    query = "%s\nFROM\n\t$1%s%s" % (select, taql_where, orderby)
+    query = f"{select}\nFROM\n\t$1{taql_where}{orderby}"
 
     return TableProxy(taql_factory, query, tables=[table_proxy],
                       __executor_key__=table_proxy.executor_key)
@@ -168,7 +168,7 @@ def group_ordering_taql(table_proxy, group_cols, index_cols, taql_where=''):
         raise ValueError("group_ordering_taql requires "
                          "len(group_cols) > 0")
     else:
-        index_group_cols = ["GAGGR(%s) as GROUP_%s" % (c, c)
+        index_group_cols = [f"GAGGR({c}) as GROUP_{c}"
                             for c in index_cols]
         # Group Row ID's
         index_group_cols.append("GROWID() AS __tablerow__")
@@ -181,9 +181,9 @@ def group_ordering_taql(table_proxy, group_cols, index_cols, taql_where=''):
         select = select_clause(group_cols + index_group_cols)
 
         if taql_where != '':
-            taql_where = "\nWHERE\n\t%s" % taql_where
+            taql_where = f"\nWHERE\n\t{taql_where}"
 
-        query = "%s\nFROM\n\t$1%s\n%s" % (select, taql_where, groupby)
+        query = f"{select}\nFROM\n\t$1{taql_where}\n{groupby}"
 
         return TableProxy(taql_factory, query, tables=[table_proxy],
                           __executor_key__=table_proxy.executor_key)
@@ -208,8 +208,8 @@ def group_row_ordering(group_order_taql, group_cols, index_cols, chunks):
             # Extract row chunking scheme
             group_row_chunks = group_chunks['row']
         except KeyError:
-            raise ValueError("No row chunking scheme "
-                             "found in %s!" % group_chunks)
+            raise ValueError(f"No row chunking scheme "
+                             f"found in {group_chunks}!")
 
         ordering_arrays.append(_group_ordering_arrays(group_order_taql,
                                                       index_cols, g, nrow,

--- a/daskms/query.py
+++ b/daskms/query.py
@@ -26,5 +26,5 @@ def where_clause(group_cols, group_vals):
     if len(group_cols) == 0:
         return ""
 
-    assign_str = ["%s=%s" % (c, v) for c, v in zip(group_cols, group_vals)]
+    assign_str = [f"{c}={v}" for c, v in zip(group_cols, group_vals)]
     return "\n\t".join(("WHERE", " AND\n\t".join(assign_str)))

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -279,7 +279,7 @@ def _col_keyword_getter(table):
 class DatasetFactory(object):
     def __init__(self, table, select_cols, group_cols, index_cols, **kwargs):
         if not table_exists(table):
-            raise ValueError("'%s' does not appear to be a CASA Table" % table)
+            raise ValueError(f"'{table}' does not appear to be a CASA Table")
 
         chunks = kwargs.pop('chunks', [{'row': _DEFAULT_ROW_CHUNKS}])
 
@@ -302,7 +302,7 @@ class DatasetFactory(object):
         self.table_proxy = kwargs.pop('table_proxy', False)
 
         if len(kwargs) > 0:
-            raise ValueError("Unhandled kwargs: %s" % kwargs)
+            raise ValueError(f"Unhandled kwargs: {kwargs}")
 
     def _table_proxy_factory(self):
         return TableProxy(pt.table, self.table_path, ack=False,
@@ -360,7 +360,7 @@ class DatasetFactory(object):
 
             # Prefix d
             gid_str = ",".join(str(gid) for gid in group_id)
-            array_suffix = "[%s]-%s" % (gid_str, short_table_name)
+            array_suffix = f"[{gid_str}]-{short_table_name}"
 
             # Create dataset variables
             group_var_dims = _dataset_variable_factory(table_proxy,

--- a/daskms/table_executor.py
+++ b/daskms/table_executor.py
@@ -44,7 +44,7 @@ class Executor(object, metaclass=ExecutorMetaClass):
         return (Executor, (self.key,))
 
     def __repr__(self):
-        return "Executor(%s)" % self.key
+        return f"Executor({self.key})"
 
     __str__ = __repr__
 

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -120,7 +120,7 @@ def proxied_method_factory(method, locktype):
                 table.unlock()
 
     else:
-        raise ValueError("Invalid locktype %s" % locktype)
+        raise ValueError(f"Invalid locktype {locktype}")
 
     _impl.__name__ = method + "_impl"
     _impl.__doc__ = ("Calls table.%s, wrapped in a %s." %
@@ -401,7 +401,7 @@ class TableProxy(object, metaclass=TableProxyMetaClass):
             return self._ex.submit(_writelock_runner, self._table_future,
                                    fn, args, kwargs)
         else:
-            raise ValueError("Invalid locktype %s" % locktype)
+            raise ValueError(f"Invalid locktype {locktype}")
 
     def __repr__(self):
         return "TableProxy[%s](%s, %s, %s)" % (

--- a/daskms/table_schemas.py
+++ b/daskms/table_schemas.py
@@ -150,8 +150,8 @@ def lookup_table_schema(table_name, lookup_str):
         try:
             return _ALL_SCHEMAS[table_type]
         except KeyError:
-            raise ValueError("No schema registered for "
-                             "table type '%s'" % table_type)
+            raise ValueError(f"No schema registered "
+                             f"for table type '{table_type}'")
 
     if not isinstance(lookup_str, (tuple, list)):
         lookup_str = [lookup_str]
@@ -165,6 +165,6 @@ def lookup_table_schema(table_name, lookup_str):
         elif isinstance(ls, str):
             table_schema.update(_ALL_SCHEMAS.get(ls, {}))
         else:
-            raise TypeError("Invalid lookup_str type '%s'" % type(ls))
+            raise TypeError(f"Invalid lookup_str type '{type(ls)}'")
 
     return table_schema

--- a/daskms/testing.py
+++ b/daskms/testing.py
@@ -16,6 +16,6 @@ def in_pytest():
 def mark_in_pytest(in_pytest=True):
     """ Mark if we're in a pytest run """
     if type(in_pytest) is not bool:
-        raise TypeError('in_pytest %s is not a boolean' % in_pytest)
+        raise TypeError(f'in_pytest {in_pytest} is not a boolean')
 
     __pytest_run_marker__['in_pytest'] = in_pytest

--- a/daskms/tests/test_dataset.py
+++ b/daskms/tests/test_dataset.py
@@ -40,12 +40,12 @@ else:
     ids=select_cols_str)
 @pytest.mark.parametrize("shapes", [
     {"row": 10, "chan": 16, "corr": 4}],
-    ids=lambda s: "shapes=%s" % s)
+    ids=lambda s: f"shapes={s}")
 @pytest.mark.parametrize("chunks", [
     {"row": 2},
     {"row": 3, "chan": 4, "corr": 1},
     {"row": 3, "chan": (4, 4, 4, 4), "corr": (2, 2)}],
-    ids=lambda c: "chunks=%s" % c)
+    ids=lambda c: f"chunks={c}")
 def test_dataset(ms, select_cols, group_cols, index_cols, shapes, chunks):
     """ Test dataset creation """
     datasets = read_datasets(ms, select_cols, group_cols,
@@ -101,12 +101,12 @@ def test_dataset(ms, select_cols, group_cols, index_cols, shapes, chunks):
     ids=select_cols_str)
 @pytest.mark.parametrize("shapes", [
     {"row": 10, "chan": 16, "corr": 4}],
-    ids=lambda s: "shapes=%s" % s)
+    ids=lambda s: f"shapes={s}")
 @pytest.mark.parametrize("chunks", [
     {"row": 2},
     {"row": 3, "chan": 4, "corr": 1},
     {"row": 3, "chan": (4, 4, 4, 4), "corr": (2, 2)}],
-    ids=lambda c: "chunks=%s" % c)
+    ids=lambda c: f"chunks={c}")
 def test_dataset_updates(ms, select_cols,
                          group_cols, index_cols,
                          shapes, chunks):

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -52,7 +52,7 @@ def test_ms_read(ms, group_cols, index_cols, select_cols):
             assert "ROWID" in ds.coords
             group_col_values = [ds.attrs[a] for a in group_cols]
             where = where_clause(group_cols, group_col_values)
-            query = "SELECT * FROM $1 %s %s" % (where, order)
+            query = f"SELECT * FROM $1 {where} {order}"
 
             with TableProxy(taql_factory, query, tables=[T]) as Q:
                 column_data = {c: Q.getcol(c).result() for c in select_cols}

--- a/daskms/tests/test_optional.py
+++ b/daskms/tests/test_optional.py
@@ -29,7 +29,7 @@ def test_variable_column_dimensions(tmp_path, column, dtype):
 
     # Column descriptor
     desc = {'desc': {'_c_order': True,
-                     'comment': '%s column' % column,
+                     'comment': f'{column} column',
                      'dataManagerGroup': '',
                      'dataManagerType': '',
                      'keywords': {},
@@ -69,7 +69,7 @@ def test_variable_column_shapes(tmp_path, column, dtype):
 
     # Column descriptor
     desc = {'desc': {'_c_order': True,
-                     'comment': '%s column' % column,
+                     'comment': f'{column} column',
                      'dataManagerGroup': '',
                      'dataManagerType': '',
                      'keywords': {},
@@ -110,7 +110,7 @@ def test_fixed_column_shapes(tmp_path, column, dtype):
 
     # Column descriptor
     desc = {'desc': {'_c_order': True,
-                     'comment': '%s column' % column,
+                     'comment': f'{column} column',
                      'dataManagerGroup': '',
                      'dataManagerType': '',
                      'keywords': {},
@@ -149,7 +149,7 @@ def test_only_row_shape(tmp_path, column, dtype):
 
     # Column descriptor
     desc = {'desc': {'_c_order': True,
-                     'comment': '%s column' % column,
+                     'comment': f'{column} column',
                      'dataManagerGroup': '',
                      'dataManagerType': '',
                      'keywords': {},
@@ -187,7 +187,7 @@ def test_scalar_ndim(tmp_path, column, dtype):
 
     # Column descriptor
     desc = {'desc': {'_c_order': True,
-                     'comment': '%s column' % column,
+                     'comment': f'{column} column',
                      'dataManagerGroup': '',
                      'dataManagerType': '',
                      'keywords': {},
@@ -218,7 +218,7 @@ def test_tiledstman(tmp_path, column, row, shape, dtype):
 
     # Column descriptor
     desc = {'desc': {'_c_order': True,
-                     'comment': '%s column' % column,
+                     'comment': f'{column} column',
                      'dataManagerGroup': 'BAZ-GROUP',
                      'dataManagerType': 'TiledColumnStMan',
                      'keywords': {},
@@ -262,7 +262,7 @@ def test_tiledstman_addcols(tmp_path, column, row, shape, dtype):
 
     # Column descriptor
     desc = {'desc': {'_c_order': True,
-                     'comment': '%s column' % column,
+                     'comment': f'{column} column',
                      'dataManagerGroup': 'BAZ_GROUP',
                      'dataManagerType': 'TiledColumnStMan',
                      'keywords': {},

--- a/daskms/tests/test_ordering.py
+++ b/daskms/tests/test_ordering.py
@@ -150,7 +150,7 @@ def test_ordering_multiple_groups(ms, group_cols, index_cols):
     {'row': 2},
     {'row': (2, 3, 4, 1)},
     {'row': (5, 3, 2)}],
-    ids=lambda c: 'chunks=%s' % (c,))
+    ids=lambda c: f'chunks={c}')
 def test_row_ordering_no_group(ms, index_cols, chunks):
     order_taql = ordering_taql(table_proxy(ms), index_cols)
     assert_liveness(2, 1)
@@ -182,7 +182,7 @@ def test_row_ordering_no_group(ms, index_cols, chunks):
     [{'row': (3, 4)}, {'row': 3}],
     [{'row': (2, 3, 2)}, {'row': (2, 1)}],
     [{'row': 2}]],
-    ids=lambda c: 'chunks=%s' % (c,))
+    ids=lambda c: f'chunks={c}')
 def test_row_ordering_multiple_groups(ms, group_cols,
                                       index_cols, chunks):
     group_taql = group_ordering_taql(table_proxy(ms), group_cols, index_cols)

--- a/daskms/tests/test_table_proxy.py
+++ b/daskms/tests/test_table_proxy.py
@@ -22,7 +22,7 @@ from daskms.utils import assert_liveness
 def test_table_proxy(ms):
     """ Base table proxy test """
     tp = TableProxy(pt.table, ms, ack=False, readonly=False)
-    tq = TableProxy(pt.taql, "SELECT UNIQUE ANTENNA1 FROM '%s'" % ms)
+    tq = TableProxy(pt.taql, f"SELECT UNIQUE ANTENNA1 FROM '{ms}'")
 
     assert_liveness(2, 1)
 
@@ -55,7 +55,7 @@ def test_table_proxy_pickling(ms):
 
 def test_taql_proxy_pickling(ms):
     """ Test taql pickling """
-    proxy = TableProxy(pt.taql, "SELECT UNIQUE ANTENNA1 FROM '%s'" % ms)
+    proxy = TableProxy(pt.taql, f"SELECT UNIQUE ANTENNA1 FROM '{ms}'")
     proxy2 = pickle.loads(pickle.dumps(proxy))
 
     assert_liveness(1, 1)

--- a/daskms/tests/test_table_schemas.py
+++ b/daskms/tests/test_table_schemas.py
@@ -16,7 +16,7 @@ from daskms.table_schemas import (lookup_table_schema,
 
 
 @pytest.mark.parametrize("filename, schema", [
-    (pjoin("bob", "qux", "FRED.MS%s" % os.sep), MS_SCHEMA),
+    (pjoin("bob", "qux", f"FRED.MS{os.sep}"), MS_SCHEMA),
     ("test.ms", MS_SCHEMA),
     ("test.ms::ANTENNA", ANTENNA_SCHEMA),
     ("test.ms::FEED", FEED_SCHEMA),

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -33,19 +33,19 @@ _root_path = Path("C:/" if platform.system() == "Windows" else os.sep,
     # Table access
     (_root_path / "test.ms",
      _root_path, "test.ms", ""),
-    (_root_path / "test.ms{s}".format(s=os.sep),
+    (_root_path / f"test.ms{os.sep}",
      _root_path, "test.ms", ""),
     (_root_path / "test.ms{s}{s}".format(s=os.sep),
      _root_path, "test.ms", ""),
     # Indirect subtable access
     (_root_path / "test.ms::SOURCE",
      _root_path, "test.ms", "SOURCE"),
-    (_root_path / "test.ms::SOURCE{s}".format(s=os.sep),
+    (_root_path / f"test.ms::SOURCE{os.sep}",
      _root_path, "test.ms", "SOURCE"),
     # Direct subtable access
     (_root_path / "test.ms" / "SOURCE",
      _root_path / "test.ms", "SOURCE", ""),
-    (_root_path / "test.ms" / "SOURCE{s}".format(s=os.sep),
+    (_root_path / "test.ms" / f"SOURCE{os.sep}",
      _root_path / "test.ms", "SOURCE", "")
 ])
 def test_table_path_split(path, root, table, subtable):

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -91,15 +91,15 @@ def table_path_split(path):
 
 
 def group_cols_str(group_cols):
-    return "group_cols=%s" % group_cols
+    return f"group_cols={group_cols}"
 
 
 def index_cols_str(index_cols):
-    return "index_cols=%s" % index_cols
+    return f"index_cols={index_cols}"
 
 
 def select_cols_str(select_cols):
-    return "select_cols=%s" % select_cols
+    return f"select_cols={select_cols}"
 
 
 def assert_liveness(table_proxies, executors, collect=True):
@@ -122,7 +122,7 @@ def assert_liveness(table_proxies, executors, collect=True):
                          "the following objects" % (i, v))
 
             for r in gc.get_referrers(v):
-                lines.append("\t%s" % str(r))
+                lines.append(f"\t{str(r)}")
 
         raise ValueError("\n".join(lines))
 
@@ -134,7 +134,7 @@ def assert_liveness(table_proxies, executors, collect=True):
                          "the following objects" % (i, v))
 
             for r in gc.get_referrers(v):
-                lines.append("\t%s" % str(r))
+                lines.append(f"\t{str(r)}")
 
         raise ValueError("\n".join(lines))
 

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -389,7 +389,7 @@ def add_row_orders(data, table_proxy, prev=None):
     elif isinstance(data, dict):
         rows = len(data)
     else:
-        raise TypeError("data %s must be a numpy array or dict" % type(data))
+        raise TypeError(f"data {type(data)} must be a numpy array or dict")
 
     # This is the first link in the chain
     if prev is None:

--- a/examples/sched_context.py
+++ b/examples/sched_context.py
@@ -38,8 +38,7 @@ def scheduler_context(args):
                 with open(args.scheduler, 'r') as f:
                     address = json.load(f)['address']
 
-            logging.info("Using distributed scheduler "
-                         "with address '{}'".format(address))
+            logging.info(f"Using distributed scheduler with address '{address}'")
             client = distributed.Client(address)
             dask.config.set(scheduler=client)
             client.restart()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 try:
     from setuptools import setup, find_packages
 except ImportError as e:
-    raise ImportError("%s\nPlease install setuptools." % e)
+    raise ImportError(f"{e}\nPlease install setuptools.")
 
 extras_require = {
     "arrow": ["pyarrow >= 3.0.0"],


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
