### PR TITLE
Change data colums expressions to be an expression, not an assignment statement

### DIFF
--- a/daskms/tests/test_expression.py
+++ b/daskms/tests/test_expression.py
@@ -21,8 +21,8 @@ def test_expressions(ms):
         for ds in datasets
     ]
 
-    string = "EXPR = DATA / (-DIR1_DATA + DIR2_DATA + DIR3_DATA)*4"
-    datasets = data_column_expr(string, datasets)
+    string = "DATA / (-DIR1_DATA + DIR2_DATA + DIR3_DATA)*4"
+    expressions = data_column_expr(string, datasets)
 
-    for i, ds in enumerate(datasets):
-        assert_array_equal(results[i], ds.EXPR.data)
+    for i, (ds, expr) in enumerate(zip(datasets, expressions)):
+        assert_array_equal(results[i], expr)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
