### PR TITLE
rethrow SyntaxError as DataColumnParseError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,7 @@ History
 * Test data fix (:pr:`128`)
 * Fix array inlining for writes (:pr:`126`)
 * Allow Multi-Layer Inlining (:pr:`125`)
-* Support DATA Column Expressions (:pr:`124`, :pr:`134`, :pr:`146`, :pr:`147`)
+* Support DATA Column Expressions (:pr:`124`, :pr:`134`, :pr:`146`, :pr:`147`, :pr:`148`)
 
 
 0.2.6 (2020-10-20)

--- a/daskms/expressions.py
+++ b/daskms/expressions.py
@@ -47,6 +47,10 @@ class Visitor(ast.NodeTransformer):
         return getattr(self.dataset, node.id).data
 
 
+class DataColumnParseError(SyntaxError):
+    pass
+
+
 def data_column_expr(statement, datasets):
     """
     Produces a list of new datasets with a
@@ -91,7 +95,10 @@ def data_column_expr(statement, datasets):
     expressions = []
 
     for ds in promoted_datasets:
-        expressions.append(Visitor(ds).visit(expr))
+        try:
+            expressions.append(Visitor(ds).visit(expr))
+        except SyntaxError:
+            raise DataColumnParseError(f"Error parsing '{expr}'")
 
     if isinstance(datasets, (list, tuple)):
         return expressions


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
