### PR TITLE
Improve zarr dataset creation

### DIFF
--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -212,7 +212,7 @@ def xds_to_zarr(xds, store, columns=None):
     return write_datasets
 
 
-def _getter_wrapper(zarray, *extents):
+def zarr_getter(zarray, *extents):
     return zarray[tuple(slice(start, end) for start, end in extents)]
 
 
@@ -289,7 +289,7 @@ def xds_from_zarr(store, columns=None, chunks=None):
             array_chunks = da.core.normalize_chunks(array_chunks, zarray.shape)
             ext_args = extent_args(dims, array_chunks)
 
-            read = da.blockwise(_getter_wrapper, dims,
+            read = da.blockwise(zarr_getter, dims,
                                 zarray, None,
                                 *ext_args,
                                 concatenate=False,

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -87,7 +87,17 @@ def test_multiprocess_create(ms, tmp_path_factory):
     writes = xds_to_zarr(ms_datasets, zarr_store)
     dask.compute(writes, scheduler="processes")
 
+    zds = xds_from_zarr(zarr_store)
 
+    for zds, msds in zip(zds, ms_datasets):
+        for k, v in msds.data_vars.items():
+            assert_array_equal(v, getattr(zds, k))
+
+        for k, v in msds.coords.items():
+            assert_array_equal(v, getattr(zds, k))
+
+        for k, v in msds.attrs.items():
+            assert_array_equal(v, getattr(zds, k))
 
 
 @pytest.mark.optional

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -76,7 +76,6 @@ def test_xds_to_zarr(ms, tmp_path_factory):
             assert_array_equal(zattr, v)
 
 
-
 @pytest.mark.skipif(xarray is None, reason="Needs xarray to rechunk")
 def test_multiprocess_create(ms, tmp_path_factory):
     zarr_store = tmp_path_factory.mktemp("zarr_store") / "test.zarr"

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -76,6 +76,20 @@ def test_xds_to_zarr(ms, tmp_path_factory):
             assert_array_equal(zattr, v)
 
 
+def test_multiprocess_create(ms, tmp_path_factory):
+    zarr_store = tmp_path_factory.mktemp("zarr_store") / "test.zarr"
+
+    ms_datasets = xds_from_ms(ms)
+
+    for i, ds in enumerate(ms_datasets):
+        ms_datasets[i] = ds.chunk({"row": 1})
+
+    writes = xds_to_zarr(ms_datasets, zarr_store)
+    dask.compute(writes, scheduler="processes")
+
+
+
+
 @pytest.mark.optional
 @pytest.mark.skipif(xarray is None, reason="depends on xarray")
 def test_xarray_to_zarr(ms, tmp_path_factory):

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -76,6 +76,8 @@ def test_xds_to_zarr(ms, tmp_path_factory):
             assert_array_equal(zattr, v)
 
 
+
+@pytest.mark.skipif(xarray is None, reason="Needs xarray to rechunk")
 def test_multiprocess_create(ms, tmp_path_factory):
     zarr_store = tmp_path_factory.mktemp("zarr_store") / "test.zarr"
 


### PR DESCRIPTION
Modfies zarr dataset creation such that only a single dask task gets to create the zarr group structure, based on a distributed file lock.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
