### PR TITLE
Fix data column expression docstrings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,7 @@ History
 * Test data fix (:pr:`128`)
 * Fix array inlining for writes (:pr:`126`)
 * Allow Multi-Layer Inlining (:pr:`125`)
-* Support DATA Column Expressions (:pr:`124`, :pr:`134`, :pr:`146`, :pr:`147`, :pr:`148`)
+* Support DATA Column Expressions (:pr:`124`, :pr:`134`, :pr:`146`, :pr:`147`, :pr:`148`, :pr:`151`)
 
 
 0.2.6 (2020-10-20)

--- a/daskms/expressions.py
+++ b/daskms/expressions.py
@@ -53,15 +53,15 @@ class DataColumnParseError(SyntaxError):
 
 def data_column_expr(statement, datasets):
     """
-    Produces a list of new datasets with a
+    Produces a list of dask arrays with a
     variable set to the result of the
     supplied expression:
 
     .. code-block:: python
 
-        ds = data_column_expr("DATA / (DIR1_DATA + DIR2_DATA)",
-                              datasets)
-        flag(ds[0].FLAG_DATA.data)
+        vis = data_column_expr("DATA / (DIR1_DATA + DIR2_DATA)",
+                               datasets)
+        flag(vis)
 
     Parameters
     ----------


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
