### PR TITLE
Copy partitioning information to write datasets

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Copy partitioning information when writing (:pr:`155`)
 * Add a `dask-ms convert` script for converting between CASA, Zarr and Parquet formats (:pr:`145`)
 * Convert code-base to f-strings with flynt (:pr:`144`)
 * Consolidate Dataset Types into daskms.dataset (:pr:`143`)

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -7,21 +7,20 @@ from numpy.testing import assert_array_equal
 import pyrap.tables as pt
 import pytest
 
-from daskms.query import orderby_clause, where_clause
-
 try:
     from dask.optimization import key_split
 except ImportError:
     from dask.utils import key_split
 
 from daskms.constants import DASKMS_PARTITION_KEY
-from daskms.utils import (group_cols_str, index_cols_str,
-                          select_cols_str, assert_liveness,
-                          table_path_split)
-from daskms.table_proxy import TableProxy, taql_factory
 from daskms.dask_ms import (xds_from_ms,
                             xds_from_table,
                             xds_to_table)
+from daskms.query import orderby_clause, where_clause
+from daskms.table_proxy import TableProxy, taql_factory
+from daskms.utils import (group_cols_str, index_cols_str,
+                          select_cols_str, assert_liveness,
+                          table_path_split)
 
 
 @pytest.mark.parametrize('group_cols', [
@@ -116,6 +115,10 @@ def test_ms_update(ms, group_cols, index_cols, select_cols):
                         DATA=(("row", "chan", "corr"), data))
 
         write = xds_to_table(nds, ms, ["STATE_ID", "DATA"])
+
+        for k, _ in nds.attrs[DASKMS_PARTITION_KEY]:
+            assert getattr(write, k) == getattr(nds, k)
+
         writes.append(write)
 
     # Do all writes in parallel

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -114,7 +114,7 @@ def test_ms_update(ms, group_cols, index_cols, select_cols):
         nds = ds.assign(STATE_ID=(("row",), state),
                         DATA=(("row", "chan", "corr"), data))
 
-        write = xds_to_table(nds, ms, ["STATE_ID", "DATA"])
+        write, = xds_to_table(nds, ms, ["STATE_ID", "DATA"])
 
         for k, _ in nds.attrs[DASKMS_PARTITION_KEY]:
             assert getattr(write, k) == getattr(nds, k)

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -672,9 +672,6 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
     # Return an empty dataset
     if len(datasets) == 0:
         return Dataset({})
-    # Return singleton
-    elif len(datasets) == 1:
-        return datasets[0]
 
     return datasets
 

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyrap.tables as pt
 
 from daskms.columns import dim_extents_array
+from daskms.constants import DASKMS_PARTITION_KEY
 from daskms.dataset import Dataset
 from daskms.dataset_schema import DatasetSchema
 from daskms.descriptors.builder import AbstractDescriptorBuilder
@@ -656,8 +657,17 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
 
             write_vars[column] = (full_dims, write_col)
 
+        # Transfer any partition information over to the write dataset
+        partition = ds.attrs.get(DASKMS_PARTITION_KEY, False)
+
+        if not partition:
+            attrs = None
+        else:
+            attrs = {DASKMS_PARTITION_KEY: partition,
+                     **{k: getattr(ds, k) for k, _ in partition}}
+
         # Append a dataset with the write operations
-        datasets.append(Dataset(write_vars))
+        datasets.append(Dataset(write_vars, attrs=attrs))
 
     # Return an empty dataset
     if len(datasets) == 0:


### PR DESCRIPTION
Closes #152
Closes #154

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
