### PR TITLE
Prefix coordinate dims to allow laziness.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Make zarr writes completely lazy (:pr:`157`)
 * Copy partitioning information when writing (:pr:`155`)
 * Add a `dask-ms convert` script for converting between CASA, Zarr and Parquet formats (:pr:`145`)
 * Convert code-base to f-strings with flynt (:pr:`144`)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -163,7 +163,12 @@ def _gen_writes(variables, chunks, columns, factory):
                              meta=np.empty((1,)*len(var.dims), np.bool))
         write = inlined_array(write, ext_args[::2])
 
-        yield name, (var.dims, write, var.attrs)
+        # The following identifies coordinates - we prefix their dims so that
+        # they can be lazily evaluated.
+        if name == var.dims[0] and len(var.dims) == 1:
+            yield name, ("__" + var.dims[0], write, var.attrs)
+        else:
+            yield name, (var.dims, write, var.attrs)
 
 
 @requires("pip install dask-ms[zarr] for zarr support",


### PR DESCRIPTION
- [X] Tests added / passed

- [X] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

### Lazy zarr writes

Currently, the following line: https://github.com/ska-sa/dask-ms/blob/c5f105e8cdf383aca28c4eb4f650973120ab31f4/daskms/experimental/zarr/__init__.py#L228 will cause early compute on the coordinates as `Dataset` will automatically interpret `data_vars` as coordinates if they meet certain criteria. This is inefficient in a distributed environment, as it will generate a large number of compute calls (high overhead).
 
This PR offers a possible solution to enforce laziness when writing xarray.Dataset objects to zarr. This is accomplished by changing the coordinates to use a new dimension which doesn't have coordinate values. This allows laziness to be retained.