### PR TITLE
Add IMAGING_WEIGHT_SPECTRUM to default Measurement Schema

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Add IMAGING_WEIGHT_SPECTRUM to default Measurement Schema (:pr:`160`)
 * Remove default time ordering from xds_from_ms (:pr:`156`)
 * Make zarr writes completely lazy (:pr:`157`)
 * Copy partitioning information when writing (:pr:`155`)

--- a/daskms/table_schemas.py
+++ b/daskms/table_schemas.py
@@ -30,7 +30,9 @@ MS_SCHEMA = {
     # Extra imaging columns
     'MODEL_DATA': {'dims': ('chan', 'corr')},
     'CORRECTED_DATA': {'dims': ('chan', 'corr')},
-    'IMAGING_WEIGHT': {'dims': ('chan',)}
+    'IMAGING_WEIGHT': {'dims': ('chan',)},
+    # Extra WSClean imaging columns
+    'IMAGING_WEIGHT_SPECTRUM': {'dims': ('chan', 'corr')},
 }
 
 ANTENNA_SCHEMA = {


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
