### PR TITLE
Ignore row dimension when fixing column shapes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Ignore row dimension when fixing column shapes (:pr:`165`)
 * Fix zarr coordinate writes (:pr:`162`)
 * Deprecate Python 3.6 (:pr:`161`)
 * Add IMAGING_WEIGHT_SPECTRUM to default Measurement Schema (:pr:`160`)

--- a/daskms/descriptors/ms.py
+++ b/daskms/descriptors/ms.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple
 from functools import reduce
 import logging
 from operator import mul
@@ -123,11 +122,10 @@ class MSDescriptorBuilder(AbstractDescriptorBuilder):
                     raise ValueError(f"'row' is not the first "
                                      f"dimension in the dimensions "
                                      f"{var.dims} of column {column}")
-                    
-                ret_val.append(DummyVar(var.dims[1:], var.shape[1:]))
-                
-            return ret_val
 
+                ret_val.append(DummyVar(var.dims[1:], var.shape[1:]))
+
+            return ret_val
 
         # Create a dictionary of all variables in all datasets
         expanded_vars = {(k, i): v for k, lv in variables.items()

--- a/daskms/descriptors/tests/test_ms_builder.py
+++ b/daskms/descriptors/tests/test_ms_builder.py
@@ -9,6 +9,7 @@ import pytest
 from daskms.dataset import Variable
 from daskms.descriptors.ms import MSDescriptorBuilder
 
+
 @pytest.fixture(params=[
     [
         {
@@ -25,6 +26,7 @@ from daskms.descriptors.ms import MSDescriptorBuilder
 ])
 def dataset_chunks(request):
     return request.param
+
 
 def _variable_factory(dims, dtype, chunks):
     shape = tuple(sum(chunks[d]) for d in dims)
@@ -44,6 +46,7 @@ def _variable_factory(dims, dtype, chunks):
 def column_schema(request):
     return request.param
 
+
 @pytest.fixture
 def variables(column_schema, dataset_chunks):
     # We want channel and correlation chunks
@@ -53,7 +56,7 @@ def variables(column_schema, dataset_chunks):
 
     return {column: [_variable_factory(dims, dtype, chunks)
                      for chunks in dataset_chunks]
-                     for column, dims, dtype in column_schema}
+            for column, dims, dtype in column_schema}
 
 
 @pytest.mark.parametrize("fixed", [True, False])


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
