### PR TITLE
Add ComplexArray -> numpy conversion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.7 (YYYY-MM-DD)
 ------------------
+* Add ComplexArray -> numpy conversion (:pr:`168`)
 * Ignore row dimension when fixing column shapes (:pr:`165`)
 * Bump pip from 9.0.1 to 19.2 (:pr:`164`)
 * Fix zarr coordinate writes (:pr:`162`)

--- a/daskms/experimental/arrow/tests/test_extensions.py
+++ b/daskms/experimental/arrow/tests/test_extensions.py
@@ -69,4 +69,3 @@ def test_arrow_numpy_conversion(test_data):
 def test_complex_type_conversion(test_data):
     array = ComplexArray.from_numpy(test_data)
     assert_array_equal(array.to_numpy(), test_data)
-    

--- a/daskms/experimental/arrow/tests/test_extensions.py
+++ b/daskms/experimental/arrow/tests/test_extensions.py
@@ -2,9 +2,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 
-from daskms.experimental.arrow.extension_types import (ComplexType,
-                                                       TensorType,
-                                                       TensorArray)
+from daskms.experimental.arrow.extension_types import (
+    ComplexType, ComplexArray, TensorType, TensorArray)
 
 pa = pytest.importorskip("pyarrow")
 
@@ -57,3 +56,17 @@ def test_arrow_numpy_conversion(test_data):
         assert pa_type == pa.from_numpy_dtype(test_data.dtype)
 
     assert_array_equal(test_data, pa_data.to_numpy())
+
+
+@pytest.mark.parametrize("dtype", [
+    np.complex64,
+    np.complex128])
+@pytest.mark.parametrize("shape", [
+    pytest.param((), marks=singleton_xfail),
+    (10,),
+    (20,)
+])
+def test_complex_type_conversion(test_data):
+    array = ComplexArray.from_numpy(test_data)
+    assert_array_equal(array.to_numpy(), test_data)
+    

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import time
 
 from dask.utils import funcname
-import numpy as np
+# The numpy module may disappear during interpreter shutdown
+# so explicitly import ndarray
+from numpy import ndarray
 
 from daskms.testing import in_pytest
 
@@ -20,7 +22,7 @@ def arg_hasher(args):
         return hash(tuple(arg_hasher(v) for v in args))
     elif isinstance(args, dict):
         return hash(tuple((k, arg_hasher(v)) for k, v in sorted(args.items())))
-    elif isinstance(args, np.ndarray):
+    elif isinstance(args, ndarray):
         # NOTE(sjperkins)
         # https://stackoverflow.com/a/16592241/1611416
         # Slowish, but we shouldn't be passing
@@ -37,7 +39,7 @@ def freeze(arg):
         return tuple(map(freeze, arg))
     elif isinstance(arg, (dict, OrderedDict)):
         return frozenset((k, freeze(v)) for k, v in sorted(arg.items()))
-    elif isinstance(arg, np.ndarray):
+    elif isinstance(arg, ndarray):
         return freeze(arg.tolist())
     else:
         return arg


### PR DESCRIPTION
Add some functionality to the Complex{Type, Array}, in order to understand how the same might be accomplished in the C++ layers.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
