### PR TITLE
Ensure natural ordering for parquet datasets

### DIFF
--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -18,6 +18,7 @@ from daskms.experimental.arrow.extension_types import TensorType
 from daskms.experimental.arrow.require_arrow import requires_arrow
 from daskms.constants import DASKMS_PARTITION_KEY
 from daskms.patterns import Multiton
+from daskms.utils import natural_order
 
 try:
     import pyarrow as pa
@@ -93,7 +94,7 @@ class ParquetFileProxy(metaclass=Multiton):
     def __lt__(self, other):
         return (isinstance(other, ParquetFileProxy) and
                 self.store == other.store and
-                self.key < other.key)
+                natural_order(self.key) < natural_order(other.key))
 
     def read_column(self, column, start=None, end=None):
         chunks = self.file.read(columns=[column]).column(column).chunks

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -7,8 +7,16 @@ import platform
 import pytest
 
 from daskms.utils import (promote_columns,
+                          natural_order,
                           table_path_split,
                           requires)
+
+
+def test_natural_order():
+    data = [f"{i}.parquet" for i in reversed(range(20))]
+    expected = [f"{i}.parquet" for i in range(20)]
+    assert sorted(data, key=natural_order) == expected
+    assert sorted(data) != expected
 
 
 @pytest.mark.parametrize("columns", [["TIME", "ANTENNA1"]])

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 import logging
 from pathlib import PurePath, Path
+import re
 import time
 
 from dask.utils import funcname
@@ -13,6 +14,11 @@ from numpy import ndarray
 from daskms.testing import in_pytest
 
 log = logging.getLogger(__name__)
+
+
+def natural_order(key):
+    return tuple(int(c) if c.isdigit() else c.lower()
+                 for c in re.split(r"(\d+)", str(key)))
 
 
 def arg_hasher(args):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
